### PR TITLE
Support transparency; many other features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,16 @@ serde_json = "1"
 tao = "0.28.0"
 wry = "0.39.5"
 schemars = "0.8.21"
+
+[features]
+transparent = ["wry/transparent"]
+devtools = ["wry/devtools"]
+
+[target.'cfg(any(feature = "transparent", feature = "devtools"))'.dependencies]
+wry = { version = "0.39.5", features = [] }
+
+[target.'cfg(feature = "transparent")'.dependencies.wry]
+features = ["transparent"]
+
+[target.'cfg(feature = "devtools")'.dependencies.wry]
+features = ["devtools"]

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "cargo test && deno run -A scripts/generate-zod.ts",
-    "build": "deno task gen && cargo build",
+    "build": "deno task gen && cargo build -F transparent",
     "example:simple": "deno run -A examples/simple.ts"
   }
 }

--- a/schemas/WebViewOptions.json
+++ b/schemas/WebViewOptions.json
@@ -32,8 +32,52 @@
     "title"
   ],
   "properties": {
+    "accept_first_mouse": {
+      "description": "Sets whether clicking an inactive window also clicks through to the webview. Default is false.",
+      "default": false,
+      "type": "boolean"
+    },
+    "autoplay": {
+      "description": "Sets whether all media can be played without user interaction.",
+      "default": false,
+      "type": "boolean"
+    },
+    "clipboard": {
+      "description": "Enables clipboard access for the page rendered on Linux and Windows.\n\nmacOS doesn’t provide such method and is always enabled by default. But your app will still need to add menu item accelerators to use the clipboard shortcuts.",
+      "default": false,
+      "type": "boolean"
+    },
+    "decorations": {
+      "description": "Sets whether the window should have a border, a title bar, etc.",
+      "default": true,
+      "type": "boolean"
+    },
+    "devtools": {
+      "description": "Enable or disable web inspector which is usually called devtools.\n\nNote this only enables devtools to the webview. To open it, you can call WebView::open_devtools, or right click the page and open it from the context menu.",
+      "default": false,
+      "type": "boolean"
+    },
+    "focused": {
+      "description": "Sets whether the webview should be focused when created. Default is false.",
+      "default": false,
+      "type": "boolean"
+    },
+    "fullscreen": {
+      "description": "Sets whether the window should be fullscreen.",
+      "default": false,
+      "type": "boolean"
+    },
+    "incognito": {
+      "description": "Run the WebView with incognito mode. Note that WebContext will be ingored if incognito is enabled.\n\nPlatform-specific: - Windows: Requires WebView2 Runtime version 101.0.1210.39 or higher, does nothing on older versions, see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive?tabs=dotnetcsharp#10121039",
+      "default": false,
+      "type": "boolean"
+    },
     "title": {
       "type": "string"
+    },
+    "transparent": {
+      "default": false,
+      "type": "boolean"
     }
   }
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -15,7 +15,16 @@ export type ClientEvent = z.infer<typeof ClientEvent>;
 
 export const WebViewOptions = z.intersection(
   z.object({
+    accept_first_mouse: z.boolean().optional(),
+    autoplay: z.boolean().optional(),
+    clipboard: z.boolean().optional(),
+    decorations: z.boolean().optional().optional(),
+    devtools: z.boolean().optional(),
+    focused: z.boolean().optional(),
+    fullscreen: z.boolean().optional(),
+    incognito: z.boolean().optional(),
     title: z.string(),
+    transparent: z.boolean().optional(),
   }),
   z.union([
     z.object({


### PR DESCRIPTION
It took me a minute to figure it out, but transparency is behind a rust flag because it uses private APIs on OSX. That unfortunately means an app built with transparency won't be publishable to the app store. That's probably not a big deal anyway though, right? 

I haven't yet decided if I'm going to matrix the build to have different binaries built with different flags (on top of the OS builds). 

Thing about builds is coming up on my list of stuff to tackle though. 