### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache Rust
+        uses: actions/cache@v2
+        id: cache-rust
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-check-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
+
+      - name: Exit early on cache hit
+        if: steps.cache-rust.outputs.cache-hit == 'true'
+        run: exit 0
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
         run: cargo check
@@ -42,6 +53,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache Rust
+        uses: actions/cache@v2
+        id: cache-rust
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
+
+      - name: Exit early on cache hit
+        if: steps.cache-rust.outputs.cache-hit == 'true'
+        run: exit 0
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -54,9 +79,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-xwin (for Windows build)
         if: matrix.target == 'x86_64-pc-windows-msvc'
@@ -94,4 +116,3 @@ jobs:
             !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/deps
             !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/build
             !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/.fingerprint
-          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,12 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
+      - name: Install libwebkit2gtk (Linux)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Install cross (for Windows build)
+      - name: Install cargo-xwin (for Windows build)
         if: matrix.target == 'x86_64-pc-windows-msvc'
-        run: cargo install cross
+        run: cargo install cargo-xwin
 
       - name: Set build flags
         id: build_flags
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build (Windows)
         if: matrix.target == 'x86_64-pc-windows-msvc'
-        run: cross build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
+        run: cargo xwin build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,26 @@ on:
   push:
 
 jobs:
+  check:
+    name: Check
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo check
+        run: cargo check
+
   build:
+    needs: check
     name: Build on ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: Build Rust Binary
+
+on:
+  push:
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }} for ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cross (for Windows build)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        run: cargo install cross
+
+      - name: Set build flags
+        id: build_flags
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "flags=--release" >> $GITHUB_OUTPUT
+            echo "build_type=release" >> $GITHUB_OUTPUT
+          else
+            echo "flags=" >> $GITHUB_OUTPUT
+            echo "build_type=debug" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build (non-Windows, non-aarch64-apple)
+        if: matrix.target != 'x86_64-pc-windows-msvc' && matrix.target != 'aarch64-apple-darwin'
+        run: cargo build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
+
+      - name: Build (aarch64-apple-darwin)
+        if: matrix.target == 'aarch64-apple-darwin'
+        run: SDKROOT=$(xcrun -sdk macosx --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version) cargo build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
+
+      - name: Build (Windows)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        run: cross build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.build_flags.outputs.build_type }}-binary-${{ matrix.target }}
+          path: |
+            target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/webview_deno_rust*
+            !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/deps
+            !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/build
+            !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/.fingerprint
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
     name: Build on ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: ${{ github.ref == 'refs/heads/main' }}
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
     name: Check
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Cache Rust
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-rust
         with:
           path: |
@@ -51,10 +51,10 @@ jobs:
             target: aarch64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Cache Rust
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-rust
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release Rust Binary
+
+on:
+  workflow_run:
+    workflows: ["Build Rust Binary"]
+    types:
+      - completed
+    branches: [main]
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          run-id: ${{github.event.workflow_run.id}}
+
+      - name: Get version from Cargo.toml
+        id: get_version
+        run: |
+          VERSION=$(grep '^version =' Cargo.toml | sed 's/.*= *"//' | sed 's/".*//')
+          echo "::set-output name=version::$VERSION"
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ steps.get_version.outputs.version }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "binary-*/webview_deno_rust*"
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+
+      - name: Release Status
+        run: echo "Release v${{ steps.get_version.outputs.version }} created or updated."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Rust Binary
 
 on:
   workflow_run:
-    workflows: ["Build Rust Binary"]
+    workflows: ["Rust Binary"]
     types:
       - completed
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,26 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           run-id: ${{github.event.workflow_run.id}}
 
+      - name: Check for artifacts
+        id: check_artifacts
+        run: |
+          if [ -z "$(find . -name 'webview_deno_rust*')" ]; then
+            echo "No artifacts found. Exiting successfully."
+            echo "artifacts_found=false" >> $GITHUB_OUTPUT
+          else
+            echo "Artifacts found. Proceeding with release."
+            echo "artifacts_found=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get version from Cargo.toml
+        if: steps.check_artifacts.outputs.artifacts_found == 'true'
         id: get_version
         run: |
           VERSION=$(grep '^version =' Cargo.toml | sed 's/.*= *"//' | sed 's/".*//')
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Release
+        if: steps.check_artifacts.outputs.artifacts_found == 'true'
         uses: ncipollo/release-action@v1
         with:
           tag: v${{ steps.get_version.outputs.version }}
@@ -40,4 +53,9 @@ jobs:
           artifactErrorsFailBuild: true
 
       - name: Release Status
+        if: steps.check_artifacts.outputs.artifacts_found == 'true'
         run: echo "Release v${{ steps.get_version.outputs.version }} created or updated."
+
+      - name: No Release Status
+        if: steps.check_artifacts.outputs.artifacts_found == 'false'
+        run: echo "No new release created as no new artifacts were found."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           run-id: ${{github.event.workflow_run.id}}

--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: macos-latest
     permissions:
       actions: write
+    outputs:
+      cached: ${{ steps.cache-rust.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v4
 
@@ -22,25 +24,17 @@ jobs:
             target
           key: ${{ runner.os }}-rust-check-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
 
-      - name: Result cached; cancel
-        if: steps.cache-rust.outputs.cache-hit == 'true'
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
-
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        if: steps.cache-rust.outputs.cache-hit != 'true'
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
 
       - name: Run cargo check
+        if: steps.cache-rust.outputs.cache-hit != 'true'
         run: cargo check
 
   build:
     needs: check
+    if: needs.check.outputs.cached != 'true'
     name: Build on ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -59,23 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Rust
-        uses: actions/cache@v4
-        id: cache-rust
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-rust-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
-
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        if: steps.cache-rust.outputs.cache-hit != 'true'
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
         with:
-          toolchain: stable
           target: ${{ matrix.target }}
-          override: true
 
       - name: Install libwebkit2gtk (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
@@ -114,19 +95,18 @@ jobs:
           fi
 
       - name: Build (non-Windows, non-aarch64-apple)
-        if: steps.cache-rust.outputs.cache-hit != 'true' && matrix.target != 'x86_64-pc-windows-msvc' && matrix.target != 'aarch64-apple-darwin'
+        if: matrix.target != 'x86_64-pc-windows-msvc' && matrix.target != 'aarch64-apple-darwin'
         run: cargo build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
 
       - name: Build (aarch64-apple-darwin)
-        if: steps.cache-rust.outputs.cache-hit != 'true' && matrix.target == 'aarch64-apple-darwin'
+        if: matrix.target == 'aarch64-apple-darwin'
         run: SDKROOT=$(xcrun -sdk macosx --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version) cargo build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
 
       - name: Build (Windows)
-        if: steps.cache-rust.outputs.cache-hit != 'true' && matrix.target == 'x86_64-pc-windows-msvc'
+        if: matrix.target == 'x86_64-pc-windows-msvc'
         run: cargo xwin build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
 
       - name: Upload artifact
-        if: steps.cache-rust.outputs.cache-hit != 'true'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build_flags.outputs.build_type }}-binary-${{ matrix.target }}

--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -7,6 +7,8 @@ jobs:
   check:
     name: Check
     runs-on: macos-latest
+    permissions:
+      actions: write
     steps:
       - uses: actions/checkout@v4
 
@@ -20,15 +22,21 @@ jobs:
             target
           key: ${{ runner.os }}-rust-check-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
 
+      - name: Result cached; cancel
+        if: steps.cache-rust.outputs.cache-hit == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+
       - name: Install Rust
-        if: steps.cache-rust.outputs.cache-hit != 'true'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
 
       - name: Run cargo check
-        if: steps.cache-rust.outputs.cache-hit != 'true'
         run: cargo check
 
   build:

--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -1,4 +1,4 @@
-name: Build Rust Binary
+name: Rust Binary
 
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-rust-check-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
+          key: ${{ runner.os }}-rust-check-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
 
       - name: Exit early on cache hit
         if: steps.cache-rust.outputs.cache-hit == 'true'
@@ -61,7 +61,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
+          key: ${{ runner.os }}-rust-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
 
       - name: Exit early on cache hit
         if: steps.cache-rust.outputs.cache-hit == 'true'
@@ -80,8 +80,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev
 
-      - name: Install cargo-xwin (for Windows build)
+      - name: Get cargo-xwin version
         if: matrix.target == 'x86_64-pc-windows-msvc'
+        id: cargo-xwin-version
+        run: |
+          VERSION=$(cargo search cargo-xwin --limit 1 | awk -F '"' '{print $2}')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Cache cargo-xwin
+        uses: actions/cache@v4
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        id: cache-cargo-xwin
+        with:
+          path: ~/.cargo/bin/cargo-xwin
+          key: ${{ runner.os }}-cargo-xwin-${{ steps.cargo-xwin-version.outputs.version }}-${{ hashFiles('rust-toolchain.toml') }}
+
+      - name: Install cargo-xwin (for Windows build)
+        if: matrix.target == 'x86_64-pc-windows-msvc' && steps.cache-cargo-xwin.outputs.cache-hit != 'true'
         run: cargo install cargo-xwin
 
       - name: Set build flags

--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -20,17 +20,15 @@ jobs:
             target
           key: ${{ runner.os }}-rust-check-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
 
-      - name: Exit early on cache hit
-        if: steps.cache-rust.outputs.cache-hit == 'true'
-        run: exit 0
-
       - name: Install Rust
+        if: steps.cache-rust.outputs.cache-hit != 'true'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
 
       - name: Run cargo check
+        if: steps.cache-rust.outputs.cache-hit != 'true'
         run: cargo check
 
   build:
@@ -63,12 +61,9 @@ jobs:
             target
           key: ${{ runner.os }}-rust-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
 
-      - name: Exit early on cache hit
-        if: steps.cache-rust.outputs.cache-hit == 'true'
-        run: exit 0
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
+        if: steps.cache-rust.outputs.cache-hit != 'true'
         with:
           toolchain: stable
           target: ${{ matrix.target }}
@@ -111,18 +106,19 @@ jobs:
           fi
 
       - name: Build (non-Windows, non-aarch64-apple)
-        if: matrix.target != 'x86_64-pc-windows-msvc' && matrix.target != 'aarch64-apple-darwin'
+        if: steps.cache-rust.outputs.cache-hit != 'true' && matrix.target != 'x86_64-pc-windows-msvc' && matrix.target != 'aarch64-apple-darwin'
         run: cargo build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
 
       - name: Build (aarch64-apple-darwin)
-        if: matrix.target == 'aarch64-apple-darwin'
+        if: steps.cache-rust.outputs.cache-hit != 'true' && matrix.target == 'aarch64-apple-darwin'
         run: SDKROOT=$(xcrun -sdk macosx --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version) cargo build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
 
       - name: Build (Windows)
-        if: matrix.target == 'x86_64-pc-windows-msvc'
+        if: steps.cache-rust.outputs.cache-hit != 'true' && matrix.target == 'x86_64-pc-windows-msvc'
         run: cargo xwin build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }}
 
       - name: Upload artifact
+        if: steps.cache-rust.outputs.cache-hit != 'true'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build_flags.outputs.build_type }}-binary-${{ matrix.target }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use tao::window::Fullscreen;
 
 #[derive(JsonSchema, Deserialize, Debug)]
 struct WebViewOptions {
+    /// Sets the title of the window.
     title: String,
     #[serde(flatten)]
     target: WebViewTarget,


### PR DESCRIPTION
This PR aims to add a build process for the rust binary part of this library. It'll upload that binary to the artifact store after its build. When a PR is merged into master a GitHub release will be generated for all the platform binaries. 

I went through a lot of iterations of caching strategies. Here's how it works:
- There's a `Check` job that runs `cargo check`, but only after checking if there's been any changes to rust files and configuration. If there hasn't been, once check is done the individual jobs run. If there _has been_ then the individual platform builds are skipped. 

In the individual platform builds, where possible I cached their dependency installs (e.g. `cargo-xwin`). 

I only use two platforms: `ubuntu-latest` and `macos-latest`. Windows is cross compiled on `ubuntu-latest` via `cargo-xwin` and `aarch64` is cross compiled on the (presumably) x86 mac server. 