### PR TITLE
Fix binary upload; rebuild on workflow change

### DIFF
--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -22,7 +22,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-rust-check-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
+          key: ${{ runner.os }}-rust-check-${{ hashFiles('.github/workflows/rust-binary.yml', 'Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
 
       - name: Install Rust
         if: steps.cache-rust.outputs.cache-hit != 'true'

--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           name: ${{ steps.build_flags.outputs.build_type }}-binary-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/webview_deno_rust*
+            target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/deno-webview*
             !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/deps
             !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/build
             !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/.fingerprint


### PR DESCRIPTION
I noticed binaries weren't uploaded because they were targeting the wrong name. Whoops. Also just updated the binary build workflow to bust cache if I change that file. 