### PR TITLE
Don't upload `.d` file

### DIFF
--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -121,6 +121,4 @@ jobs:
           name: ${{ steps.build_flags.outputs.build_type }}-binary-${{ matrix.target }}
           path: |
             target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/deno-webview*
-            !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/deps
-            !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/build
-            !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/.fingerprint
+            !target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/deno-webview.d


### PR DESCRIPTION
Tweaks the asset upload to only be the binary and to explicitly not avoid the `.d` file.