### PR TITLE
Add version to binary name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "deno-webview"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno-webview"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [profile.release]

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
     "dev": "deno run --watch main.ts",
     "gen": "cargo test && deno run -A scripts/generate-zod.ts && deno run -A scripts/sync-versions.ts",
     "build": "deno task gen && cargo build -F transparent",
-    "example:simple": "deno run -A examples/simple.ts"
+    "example:simple": "WEBVIEW_BIN=./target/debug/deno-webview deno run -A examples/simple.ts"
   },
   "publish": {
     "include": ["README.md", "LICENSE", "src/**/*.ts"]

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -15,8 +15,8 @@ const libContent = await Deno.readTextFile(libPath);
 
 // Replace the version in the URL
 const updatedContent = libContent.replace(
-  /releases\/download\/v\d+\.\d+\.\d+\/deno-webview/,
-  `releases/download/v${latestVersion}/deno-webview`,
+  /const BIN_VERSION = "[^"]+"/,
+  `const BIN_VERSION = "${latestVersion}"`,
 );
 
 // Write the updated content back to src/lib.ts

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -10,6 +10,9 @@ import type { Except } from "npm:type-fest";
 import { join } from "jsr:@std/path";
 import { ensureDir, exists } from "jsr:@std/fs";
 
+/* The version of the webview binary to use; should match the cargo package version */
+const BIN_VERSION = "0.1.5";
+
 type JSON =
   | string
   | number
@@ -83,7 +86,7 @@ async function getWebViewBin(options: WebViewOptions) {
     : "";
 
   const cacheDir = getCacheDir();
-  const fileName = `deno-webview${flags}${
+  const fileName = `deno-webview-${BIN_VERSION}${flags}${
     Deno.build.os === "windows" ? ".exe" : ""
   }`;
   const filePath = join(cacheDir, fileName);
@@ -95,7 +98,7 @@ async function getWebViewBin(options: WebViewOptions) {
 
   // If not in cache, download it
   let url =
-    "https://github.com/zephraph/webview/releases/download/v0.1.4/deno-webview";
+    `https://github.com/zephraph/webview/releases/download/v${BIN_VERSION}/deno-webview`;
   switch (Deno.build.os) {
     case "darwin": {
       url += "-mac" + flags;

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,6 @@ fn main() -> wry::Result<()> {
             }
             Event::MainEventsCleared => {
                 if let Ok(req) = rx.try_recv() {
-                    eprintln!("Received event: {:?}", event);
                     match req {
                         Request::Eval { id, js } => {
                             let result = webview.evaluate_script(&js);


### PR DESCRIPTION
This PR makes a minor update to the binary to remove some logging. Otherwise it updates the naming strategy of the downloaded binary to have the version number included. That way the cache only ignores it if the same version is downloaded. 