### PR TITLE
Document permissions; improve examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,55 @@
 # @justbe/webview
 
-This package is a webview binding for Deno using [Wry](https://github.com/tauri-apps/wry) to interface with the webview and [Tao](https://github.com/tauri-apps/tao) to handle window management.
+A light, cross-platform library for building web-based desktop apps.
 
-When Wry initializes on OSX it takes over the main thread of the process it's running in. To ensure creating the webview doesn't lock up the Deno process the webview will be created in a separate process.
+## Example
+
+```typescript
+import { createWebView } from "jsr:@justbe/webview";
+
+using webview = await createWebView({
+  title: "Example",
+  html: "<h1>Hello, World!</h1>",
+  devtools: true
+});
+
+webview.on("started", async () => {
+  await webview.openDevTools();
+  await webview.eval("console.log('This is printed from eval!')");
+});
+
+await webview.waitUntilClosed();
+```
+
+## Permissions
+
+When executing this package, it checks to see if you have the required binary for interfacing with the OS's webview. If it doesn't exist, it downloads it to a cache directory and executes it. This yields a few different permission code paths to be aware of.
+
+### Binary not in cache
+
+This will be true of a first run of the package. These are the following permission requests you can expect to see:
+
+- Read HOME env -- Used to locate the cache directory
+- Read <cache>/deno-webview/deno-webview-<version> -- Tries to read the binary from cache
+- net to github.com:443 -- Connects to GitHub releases to try to download the binary (will be redirected)
+- net to objects.githubusercontent.com:443 -- GitHub's CDN for the actual download
+- Read <cache>/deno-webview/ -- Reads the cache directory
+- Write <cache>/deno-webview/deno-webview-<version> -- Writes the binary
+- Run <cache>/deno-webview/deno-webview-<version> -- Runs the binary
+
+### Binary cached
+
+On subsequent runs you can expect fewer permission requests:
+
+- Read HOME env -- Use to locate the cache directory
+- Read <cache>/deno-webview/deno-webview-<version>
+- Run <cache>/deno-webview/deno-webview-<version>
+
+### Allowed `WEBVIEW_BIN`
+
+`WEBVIEW_BIN` is a special environment variable that, if present and allowed, will short circuit
+the binary resolution process in favor of the path specified. In this case there will be only one permission:
+
+- Run <WEBVIEW_BIN>
+
+Note that this environment variable will never be _explicitly_ requested. If the script detects it's not allowed to read this env var it just skips this code path altogether.

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,8 @@
     "gen:rust": "cargo test",
     "gen:deno": "deno run -A scripts/generate-zod.ts && deno run -A scripts/sync-versions.ts",
     "build": "deno task gen && cargo build -F transparent",
-    "example:simple": "WEBVIEW_BIN=./target/debug/deno-webview deno run -A examples/simple.ts"
+    "run": "export WEBVIEW_BIN=./target/debug/deno-webview && deno run -E=WEBVIEW_BIN --allow-run=$WEBVIEW_BIN",
+    "example:simple": "deno task run examples/simple.ts"
   },
   "publish": {
     "include": ["README.md", "LICENSE", "src/**/*.ts"]

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -8,6 +8,8 @@
  * import { createWebView } from "jsr:@justbe/webview";
  *
  * using webview = await createWebView({ title: "My Webview" });
+ *
+ * await webview.waitUntilClosed();
  * ```
  */
 
@@ -94,7 +96,10 @@ const returnAck = (result: WebViewResponse) => {
 };
 
 async function getWebViewBin(options: WebViewOptions) {
-  if (Deno.permissions.querySync({ name: "env" }).state === "granted") {
+  if (
+    Deno.permissions.querySync({ name: "env", variable: "WEBVIEW_BIN" })
+      .state === "granted"
+  ) {
     const binPath = Deno.env.get("WEBVIEW_BIN");
     if (binPath) return binPath;
   }


### PR DESCRIPTION
Adds an example and some documentation about what permissions are used in the readme. Updates the `WEBVIEW_BIN` permission checking a bit too, just to make sure all env read access isn't needed to enable that feature. 