### PR TITLE
Fix events not firing

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@justbe/webview",
   "exports": "./src/lib.ts",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "deno task gen:rust && deno task gen:deno",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -282,7 +282,7 @@ export class WebView implements Disposable {
     event: WebViewNotification["$type"],
     callback: (event: WebViewNotification) => void,
   ) {
-    this.#internalEvent.on(event, callback);
+    this.#externalEvent.on(event, callback);
   }
 
   /**
@@ -292,7 +292,7 @@ export class WebView implements Disposable {
     event: WebViewNotification["$type"],
     callback: (event: WebViewNotification) => void,
   ) {
-    this.#internalEvent.once(event, callback);
+    this.#externalEvent.once(event, callback);
   }
 
   async setTitle(title: string): Promise<void> {


### PR DESCRIPTION
The public event listener interface was listening on the wrong channel so `start`, `closed` events weren't being received. 