### PR TITLE
Drop webview prefix from tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.0.8 (binary 0.1.7) -- 2024-09-23
+
+NOTE: The binary version was bumped this release, but it doesn't actually have changes.
+This is just me forcing a new release to be published.
+
+- Fixed the release URL to ensure the download comes from the correct place
+
 ## 0.0.7 (binary 0.1.6) -- 2024-09-23
 
 - Added this changelog

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "deno-webview"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno-webview"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [profile.release]

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@justbe/webview",
   "exports": "./src/lib.ts",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "deno task gen:rust && deno task gen:deno",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,7 +38,7 @@ export type { WebViewOptions } from "./schemas.ts";
 
 // Should match the cargo package version
 /** The version of the webview binary that's expected */
-export const BIN_VERSION = "0.1.6";
+export const BIN_VERSION = "0.1.7";
 
 type JSON =
   | string

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -140,7 +140,7 @@ async function getWebViewBin(options: WebViewOptions) {
 
   // If not in cache, download it
   let url =
-    `https://github.com/zephraph/webview/releases/download/v${BIN_VERSION}/deno-webview`;
+    `https://github.com/zephraph/webview/releases/download/webview-v${BIN_VERSION}/deno-webview`;
   switch (Deno.build.os) {
     case "darwin": {
       url += "-mac" + flags;


### PR DESCRIPTION
Just realized pre-prending `webview` to the tag would likely break things. I've dropped that for now. 

Hopefully this doesn't break everything, ha.