### PR TITLE
Queryable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.9 (binary 0.1.8) -- 2024-09-23
+
+- Adds a `getVersion` method to `Webview` that returns the binary version.
+- Adds a check on startup that compares the expected version to the current version.
+- Adds slightly more graceful error handling to deserialization errors in the deno code.
+
 ## 0.0.8 (binary 0.1.7) -- 2024-09-23
 
 NOTE: The binary version was bumped this release, but it doesn't actually have changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "deno-webview"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno-webview"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [profile.release]

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@justbe/webview",
   "exports": "./src/lib.ts",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "deno task gen:rust && deno task gen:deno",

--- a/schemas/WebViewMessage.json
+++ b/schemas/WebViewMessage.json
@@ -47,7 +47,8 @@
         {
           "type": "object",
           "required": [
-            "$type"
+            "$type",
+            "version"
           ],
           "properties": {
             "$type": {
@@ -55,6 +56,9 @@
               "enum": [
                 "started"
               ]
+            },
+            "version": {
+              "type": "string"
             }
           }
         },

--- a/schemas/WebViewRequest.json
+++ b/schemas/WebViewRequest.json
@@ -7,6 +7,24 @@
       "type": "object",
       "required": [
         "$type",
+        "id"
+      ],
+      "properties": {
+        "$type": {
+          "type": "string",
+          "enum": [
+            "getVersion"
+          ]
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "$type",
         "id",
         "js"
       ],

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -234,7 +234,12 @@ export class WebView implements Disposable {
     return new Promise((resolve) => {
       // Setup listener before sending the message to avoid race conditions
       this.#internalEvent.once(id, (event) => {
-        resolve(WebViewResponse.parse(event));
+        const result = WebViewResponse.safeParse(event);
+        if (result.success) {
+          resolve(result.data);
+        } else {
+          resolve({ $type: "err", id, message: result.error.message });
+        }
       });
       this.#stdin.write(
         new TextEncoder().encode(
@@ -256,11 +261,16 @@ export class WebView implements Disposable {
       if (NulCharIndex === -1) {
         continue;
       }
-      const result = WebViewMessage.parse(
+      const result = WebViewMessage.safeParse(
         JSON.parse(this.#buffer.slice(0, NulCharIndex)),
       );
       this.#buffer = this.#buffer.slice(NulCharIndex + 1);
-      return result;
+      if (result.success) {
+        return result.data;
+      } else {
+        console.error("Error parsing message", result.error);
+        return result;
+      }
     }
   }
 
@@ -268,11 +278,34 @@ export class WebView implements Disposable {
     while (true) {
       const result = await this.#recv();
       if (!result) return;
+      if ("error" in result) {
+        // TODO: This should be handled more gracefully
+        for (const issue of result.error.issues) {
+          switch (issue.code) {
+            case "invalid_type":
+              console.error(
+                `Invalid type: expected ${issue.expected} but got ${issue.received}`,
+              );
+              break;
+            default:
+              console.error(`Unknown error: ${issue.message}`);
+          }
+        }
+        continue;
+      }
       const { $type, data } = result;
 
       if ($type === "notification") {
         const notification = data;
         this.#externalEvent.emit(notification.$type);
+        if (notification.$type === "started") {
+          const version = notification.version;
+          if (version !== BIN_VERSION) {
+            console.warn(
+              `Expected webview to be version ${BIN_VERSION} but got ${version}. Some features may not work as expected.`,
+            );
+          }
+        }
         if (notification.$type === "closed") {
           return;
         }
@@ -310,6 +343,14 @@ export class WebView implements Disposable {
     callback: (event: WebViewNotification) => void,
   ) {
     this.#externalEvent.once(event, callback);
+  }
+
+  /**
+   * Gets the version of the webview binary.
+   */
+  async getVersion(): Promise<string> {
+    const result = await this.#send({ $type: "getVersion" });
+    return returnResult(result, "string");
   }
 
   /**

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,7 +38,7 @@ export type { WebViewOptions } from "./schemas.ts";
 
 // Should match the cargo package version
 /** The version of the webview binary that's expected */
-export const BIN_VERSION = "0.1.7";
+export const BIN_VERSION = "0.1.8";
 
 type JSON =
   | string

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -40,6 +40,10 @@ export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
 
 export type WebViewRequest =
   | {
+    $type: "getVersion";
+    id: string;
+  }
+  | {
     $type: "eval";
     id: string;
     js: string;
@@ -69,6 +73,7 @@ export type WebViewRequest =
 export const WebViewRequest: z.ZodType<WebViewRequest> = z.discriminatedUnion(
   "$type",
   [
+    z.object({ $type: z.literal("getVersion"), id: z.string() }),
     z.object({ $type: z.literal("eval"), id: z.string(), js: z.string() }),
     z.object({
       $type: z.literal("setTitle"),
@@ -136,6 +141,7 @@ export type WebViewMessage =
     data:
       | {
         $type: "started";
+        version: string;
       }
       | {
         $type: "closed";
@@ -177,7 +183,7 @@ export const WebViewMessage: z.ZodType<WebViewMessage> = z.discriminatedUnion(
     z.object({
       $type: z.literal("notification"),
       data: z.discriminatedUnion("$type", [
-        z.object({ $type: z.literal("started") }),
+        z.object({ $type: z.literal("started"), version: z.string() }),
         z.object({ $type: z.literal("closed") }),
       ]),
     }),


### PR DESCRIPTION
Fixes #46 

This adds a `getVersion` method to `Webview` that allows querying the version from the binary. It also adds the version to the `Started` lifecycle method to do an initial comparison when the binary starts and warn the user right away if there's a version mismatch. 