### PR TITLE
Prefix tag release with something else

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git tag -a v${{ steps.latest_version.outputs.version }} -m "Release ${{ steps.latest_version.outputs.version }}"
-          git push origin v${{ steps.latest_version.outputs.version }}
+          git tag -a deno-v${{ steps.latest_version.outputs.version }} -m "Release ${{ steps.latest_version.outputs.version }}"
+          git push origin deno-v${{ steps.latest_version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Instead of just `v0.0.0` I'm tagging the deno code with `deno-v0.0.0`. That just makes sure there's a maximum different between the deno and rust code. 