### PR TITLE
Only run publish step after verify completes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
 name: Publish
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Verify"]
+    types:
+      - completed
+    branches: [main]
 
 jobs:
   publish:


### PR DESCRIPTION
Publish shouldn't _always_ be ran. It should only happen on main after `Verify` finishes. 