### PR TITLE
Implement webview IPC support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.10 (binary 0.1.9) -- 2024-09-23
+
+- Adds an `ipc` flag to enable sending messages from the webview back to the host deno process.
+- Adds an IPC example
+- Updates notifications to pass message bodies through
+
 ## 0.0.9 (binary 0.1.8) -- 2024-09-23
 
 - Adds a `getVersion` method to `Webview` that returns the binary version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "deno-webview"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno-webview"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [profile.release]

--- a/deno.json
+++ b/deno.json
@@ -7,9 +7,10 @@
     "gen": "deno task gen:rust && deno task gen:deno",
     "gen:rust": "cargo test",
     "gen:deno": "deno run -A scripts/generate-schema.ts && deno run -A scripts/sync-versions.ts",
-    "build": "deno task gen && cargo build -F transparent",
+    "build": "deno task gen && cargo build -F transparent -F devtools",
     "run": "export WEBVIEW_BIN=./target/debug/deno-webview && deno run -E=WEBVIEW_BIN --allow-run=$WEBVIEW_BIN",
-    "example:simple": "deno task run examples/simple.ts"
+    "example:simple": "deno task run examples/simple.ts",
+    "example:ipc": "deno task run examples/ipc.ts"
   },
   "publish": {
     "include": ["README.md", "LICENSE", "src/**/*.ts"]

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@justbe/webview",
   "exports": "./src/lib.ts",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "deno task gen:rust && deno task gen:deno",

--- a/examples/ipc.ts
+++ b/examples/ipc.ts
@@ -1,0 +1,15 @@
+import { createWebView } from "../src/lib.ts";
+
+using webview = await createWebView({
+  title: "Simple",
+  html:
+    '<button onclick="window.ipc.postMessage(`button clicked ${Date.now()}`)">Click me</button>',
+  ipc: true,
+});
+
+// @ts-expect-error event emitter types still need to be corrected
+webview.on("ipc", ({ message }) => {
+  console.log(message);
+});
+
+await webview.waitUntilClosed();

--- a/schemas/WebViewMessage.json
+++ b/schemas/WebViewMessage.json
@@ -65,6 +65,24 @@
         {
           "type": "object",
           "required": [
+            "$type",
+            "message"
+          ],
+          "properties": {
+            "$type": {
+              "type": "string",
+              "enum": [
+                "ipc"
+              ]
+            },
+            "message": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "$type"
           ],
           "properties": {

--- a/schemas/WebViewOptions.json
+++ b/schemas/WebViewOptions.json
@@ -72,6 +72,11 @@
       "default": false,
       "type": "boolean"
     },
+    "ipc": {
+      "description": "Sets whether host should be able to receive messages from the webview via `window.ipc.postMessage`.",
+      "default": false,
+      "type": "boolean"
+    },
     "title": {
       "description": "Sets the title of the window.",
       "type": "string"

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,7 +38,7 @@ export type { WebViewOptions } from "./schemas.ts";
 
 // Should match the cargo package version
 /** The version of the webview binary that's expected */
-export const BIN_VERSION = "0.1.8";
+export const BIN_VERSION = "0.1.9";
 
 type JSON =
   | string

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -296,17 +296,17 @@ export class WebView implements Disposable {
       const { $type, data } = result;
 
       if ($type === "notification") {
-        const notification = data;
-        this.#externalEvent.emit(notification.$type);
-        if (notification.$type === "started") {
-          const version = notification.version;
+        const { $type, ...body } = data;
+        this.#externalEvent.emit($type, body);
+        if (data.$type === "started") {
+          const version = data.version;
           if (version !== BIN_VERSION) {
             console.warn(
               `Expected webview to be version ${BIN_VERSION} but got ${version}. Some features may not work as expected.`,
             );
           }
         }
-        if (notification.$type === "closed") {
+        if ($type === "closed") {
           return;
         }
       }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -11,6 +11,7 @@ export type WebViewOptions =
     focused?: boolean;
     fullscreen?: boolean;
     incognito?: boolean;
+    ipc?: boolean;
     title: string;
     transparent?: boolean;
   }
@@ -32,6 +33,7 @@ export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
     focused: z.boolean().optional(),
     fullscreen: z.boolean().optional(),
     incognito: z.boolean().optional(),
+    ipc: z.boolean().optional(),
     title: z.string(),
     transparent: z.boolean().optional(),
   }),
@@ -144,6 +146,10 @@ export type WebViewMessage =
         version: string;
       }
       | {
+        $type: "ipc";
+        message: string;
+      }
+      | {
         $type: "closed";
       };
   }
@@ -184,6 +190,7 @@ export const WebViewMessage: z.ZodType<WebViewMessage> = z.discriminatedUnion(
       $type: z.literal("notification"),
       data: z.discriminatedUnion("$type", [
         z.object({ $type: z.literal("started"), version: z.string() }),
+        z.object({ $type: z.literal("ipc"), message: z.string() }),
         z.object({ $type: z.literal("closed") }),
       ]),
     }),


### PR DESCRIPTION
Enables passing a message from the webview back to the host deno process. 

```typescript
using webview = createWebView({
  ipc: true,
  // ...
})

webview.on("ipc", ({ message }) => {
  console.log(message);
});

webview.on("started", () => {
  await webview.eval("window.ipc.postMessage('hello from the webview')")
});


```