### PR TITLE
Add tldraw example

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,9 +8,10 @@
     "gen:rust": "cargo test",
     "gen:deno": "deno run -A scripts/generate-schema.ts && deno run -A scripts/sync-versions.ts",
     "build": "deno task gen && cargo build -F transparent -F devtools",
-    "run": "export WEBVIEW_BIN=./target/debug/deno-webview && deno run -E=WEBVIEW_BIN --allow-run=$WEBVIEW_BIN",
+    "run": "export WEBVIEW_BIN=./target/debug/deno-webview && deno run -E -R --allow-run",
     "example:simple": "deno task run examples/simple.ts",
-    "example:ipc": "deno task run examples/ipc.ts"
+    "example:ipc": "deno task run examples/ipc.ts",
+    "example:tldraw": "deno task run examples/tldraw.ts"
   },
   "publish": {
     "include": ["README.md", "LICENSE", "src/**/*.ts"]

--- a/deno.lock
+++ b/deno.lock
@@ -24,6 +24,7 @@
       "npm:@types/json-schema": "npm:@types/json-schema@7.0.15",
       "npm:@types/node": "npm:@types/node@18.16.19",
       "npm:effection": "npm:effection@3.0.3",
+      "npm:esbuild": "npm:esbuild@0.23.1",
       "npm:json-schema-to-zod": "npm:json-schema-to-zod@2.4.1",
       "npm:ts-pattern": "npm:ts-pattern@5.0.6",
       "npm:type-fest": "npm:type-fest@4.25.0",
@@ -101,6 +102,102 @@
       }
     },
     "npm": {
+      "@esbuild/aix-ppc64@0.23.1": {
+        "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+        "dependencies": {}
+      },
+      "@esbuild/android-arm64@0.23.1": {
+        "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+        "dependencies": {}
+      },
+      "@esbuild/android-arm@0.23.1": {
+        "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+        "dependencies": {}
+      },
+      "@esbuild/android-x64@0.23.1": {
+        "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+        "dependencies": {}
+      },
+      "@esbuild/darwin-arm64@0.23.1": {
+        "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+        "dependencies": {}
+      },
+      "@esbuild/darwin-x64@0.23.1": {
+        "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+        "dependencies": {}
+      },
+      "@esbuild/freebsd-arm64@0.23.1": {
+        "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+        "dependencies": {}
+      },
+      "@esbuild/freebsd-x64@0.23.1": {
+        "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-arm64@0.23.1": {
+        "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-arm@0.23.1": {
+        "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-ia32@0.23.1": {
+        "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-loong64@0.23.1": {
+        "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-mips64el@0.23.1": {
+        "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-ppc64@0.23.1": {
+        "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-riscv64@0.23.1": {
+        "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-s390x@0.23.1": {
+        "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-x64@0.23.1": {
+        "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+        "dependencies": {}
+      },
+      "@esbuild/netbsd-x64@0.23.1": {
+        "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+        "dependencies": {}
+      },
+      "@esbuild/openbsd-arm64@0.23.1": {
+        "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+        "dependencies": {}
+      },
+      "@esbuild/openbsd-x64@0.23.1": {
+        "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+        "dependencies": {}
+      },
+      "@esbuild/sunos-x64@0.23.1": {
+        "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+        "dependencies": {}
+      },
+      "@esbuild/win32-arm64@0.23.1": {
+        "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+        "dependencies": {}
+      },
+      "@esbuild/win32-ia32@0.23.1": {
+        "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+        "dependencies": {}
+      },
+      "@esbuild/win32-x64@0.23.1": {
+        "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+        "dependencies": {}
+      },
       "@types/json-schema@7.0.15": {
         "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
         "dependencies": {}
@@ -112,6 +209,35 @@
       "effection@3.0.3": {
         "integrity": "sha512-9ASCaJ44flDoEKUUJtn9drfIomn2z30sZUw7//crbq+eltMu09AyILcouXwpMkcHR8TsD5hDvTTsOLHswWRxXQ==",
         "dependencies": {}
+      },
+      "esbuild@0.23.1": {
+        "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+        "dependencies": {
+          "@esbuild/aix-ppc64": "@esbuild/aix-ppc64@0.23.1",
+          "@esbuild/android-arm": "@esbuild/android-arm@0.23.1",
+          "@esbuild/android-arm64": "@esbuild/android-arm64@0.23.1",
+          "@esbuild/android-x64": "@esbuild/android-x64@0.23.1",
+          "@esbuild/darwin-arm64": "@esbuild/darwin-arm64@0.23.1",
+          "@esbuild/darwin-x64": "@esbuild/darwin-x64@0.23.1",
+          "@esbuild/freebsd-arm64": "@esbuild/freebsd-arm64@0.23.1",
+          "@esbuild/freebsd-x64": "@esbuild/freebsd-x64@0.23.1",
+          "@esbuild/linux-arm": "@esbuild/linux-arm@0.23.1",
+          "@esbuild/linux-arm64": "@esbuild/linux-arm64@0.23.1",
+          "@esbuild/linux-ia32": "@esbuild/linux-ia32@0.23.1",
+          "@esbuild/linux-loong64": "@esbuild/linux-loong64@0.23.1",
+          "@esbuild/linux-mips64el": "@esbuild/linux-mips64el@0.23.1",
+          "@esbuild/linux-ppc64": "@esbuild/linux-ppc64@0.23.1",
+          "@esbuild/linux-riscv64": "@esbuild/linux-riscv64@0.23.1",
+          "@esbuild/linux-s390x": "@esbuild/linux-s390x@0.23.1",
+          "@esbuild/linux-x64": "@esbuild/linux-x64@0.23.1",
+          "@esbuild/netbsd-x64": "@esbuild/netbsd-x64@0.23.1",
+          "@esbuild/openbsd-arm64": "@esbuild/openbsd-arm64@0.23.1",
+          "@esbuild/openbsd-x64": "@esbuild/openbsd-x64@0.23.1",
+          "@esbuild/sunos-x64": "@esbuild/sunos-x64@0.23.1",
+          "@esbuild/win32-arm64": "@esbuild/win32-arm64@0.23.1",
+          "@esbuild/win32-ia32": "@esbuild/win32-ia32@0.23.1",
+          "@esbuild/win32-x64": "@esbuild/win32-x64@0.23.1"
+        }
       },
       "json-schema-to-zod@2.4.1": {
         "integrity": "sha512-aMoez9TxgnfLAIZaWTPaQ+j7rOt1K9Ew/TBI85XcnhcFlo/47b1MDgpi4r07XndLSZWOX/KsJiRJvhdzSvo2Dw==",

--- a/examples/tldraw.ts
+++ b/examples/tldraw.ts
@@ -1,0 +1,65 @@
+import { createWebView } from "../src/lib.ts";
+import * as esbuild from "npm:esbuild";
+
+const tldrawApp = `
+import { Tldraw } from "tldraw";
+import { createRoot } from "react-dom/client";
+
+function App() {
+  return (
+    <>
+      <div style={{ position: "absolute", inset: 0 }}>
+        <Tldraw cameraOptions={{ wheelBehavior: "zoom" }} />
+      </div>
+    </>
+  );
+}
+
+createRoot(document.querySelector("main")).render(<App />);
+`;
+
+const app = await esbuild.transform(tldrawApp, {
+  loader: "jsx",
+  jsx: "automatic",
+  target: "esnext",
+  format: "esm",
+  minify: false,
+  sourcemap: false,
+});
+
+const webview = await createWebView({
+  title: "TLDraw",
+  html: `
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap"/>
+        <link rel="stylesheet" href="https://esm.sh/tldraw@2.3.0/tldraw.css"/>
+        <style> body { font-family: "Inter"; } </style>
+      </head>
+      <body>
+        <main></main>
+        <script type="importmap">
+          {
+            "imports": {
+              "tldraw": "https://esm.sh/tldraw@2.3.0?bundle-deps",
+              "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime?bundle-deps",
+              "react-dom/client": "https://esm.sh/react-dom@18.3.1/client?bundle-deps"
+            }
+          }
+        </script>
+        <script type="module">
+          ${app.code}
+        </script>
+      </body>
+    </html>
+  `,
+  devtools: true,
+});
+
+webview.on("started", () => {
+  webview.openDevTools();
+});
+
+await webview.waitUntilClosed();

--- a/examples/tldraw.ts
+++ b/examples/tldraw.ts
@@ -55,11 +55,6 @@ const webview = await createWebView({
       </body>
     </html>
   `,
-  devtools: true,
-});
-
-webview.on("started", () => {
-  webview.openDevTools();
 });
 
 await webview.waitUntilClosed();


### PR DESCRIPTION
Something to note:

When I was first attempting this I added a [persistence key](https://tldraw.dev/docs/persistence#The-persistenceKey-prop) which attempts to persist the canvas in localstorage. Using the `html` property for initializing the webview means that the [origin is null](https://docs.rs/wry/latest/wry/struct.WebViewBuilder.html#warning-1) which causes indexeddb to throw an error and tldraw to force a reload. Another consequence of using `html` to initialize is that if the page reloads you [end up with an empty page](https://github.com/tauri-apps/wry/issues/1367). I've got a [PR in Wry](https://github.com/tauri-apps/wry/pull/1368) to add a `load_html` method so that the html can be re-initialized after a reload. I'll also eventually wire up [`with_navigation_handler`](https://docs.rs/wry/latest/wry/struct.WebViewBuilder.html#method.with_navigation_handler) so users can prevent redirects if they want. 

Anyway, this is a huge milestone!

![CleanShot 2024-09-25 at 10 32 37](https://github.com/user-attachments/assets/b939a57f-7d65-44ad-9689-0caa529dfe2c)
