### PR TITLE
Support load html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.13 (binary 0.1.11) -- 2024-09-26
+
+- added `webview.loadHtml(...)`
+
 ## 0.0.12 (binary 0.1.10) -- 2024-09-26
 
 BREAKING CHANGES

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "deno-webview"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno-webview"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 
 [profile.release]

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@justbe/webview",
   "exports": "./src/lib.ts",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "deno task gen:rust && deno task gen:deno",

--- a/examples/load-html.ts
+++ b/examples/load-html.ts
@@ -1,0 +1,12 @@
+import { createWebView } from "../src/lib.ts";
+
+using webview = await createWebView({
+  title: "Load Html Example",
+  html: "<h1>Initial html</h1>",
+});
+
+webview.on("started", async () => {
+  await webview.loadHtml("<h1>Updated html!</h1>");
+});
+
+await webview.waitUntilClosed();

--- a/schemas/WebViewRequest.json
+++ b/schemas/WebViewRequest.json
@@ -259,6 +259,28 @@
           ]
         }
       }
+    },
+    {
+      "type": "object",
+      "required": [
+        "$type",
+        "html",
+        "id"
+      ],
+      "properties": {
+        "$type": {
+          "type": "string",
+          "enum": [
+            "loadHtml"
+          ]
+        },
+        "html": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
     }
   ],
   "definitions": {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,7 +38,7 @@ export type { WebViewOptions } from "./schemas.ts";
 
 // Should match the cargo package version
 /** The version of the webview binary that's expected */
-export const BIN_VERSION = "0.1.10";
+export const BIN_VERSION = "0.1.11";
 
 type JSON =
   | string

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -464,6 +464,14 @@ export class WebView implements Disposable {
   }
 
   /**
+   * Reloads the webview with the provided html.
+   */
+  async loadHtml(html: string): Promise<void> {
+    const result = await this.#send({ $type: "loadHtml", html });
+    return returnAck(result);
+  }
+
+  /**
    * Destroys the webview and cleans up resources.
    *
    * Alternatively you can use the disposible interface.

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,10 @@ enum Request {
         id: String,
         minimized: Option<bool>,
     },
+    LoadHtml {
+        id: String,
+        html: String,
+    },
 }
 
 /// Responses from the webview to the client.
@@ -424,6 +428,10 @@ fn main() -> wry::Result<()> {
                             let minimized = minimized.unwrap_or(!window.is_minimized());
                             eprintln!("Minimize: {:?}", minimized);
                             window.set_minimized(minimized);
+                            res(Response::Ack { id });
+                        }
+                        Request::LoadHtml { id, html } => {
+                            webview.load_html(&html).unwrap();
                             res(Response::Ack { id });
                         }
                     }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -136,6 +136,11 @@ export type WebViewRequest =
     $type: "minimize";
     id: string;
     minimized?: boolean;
+  }
+  | {
+    $type: "loadHtml";
+    html: string;
+    id: string;
   };
 export const WebViewRequest: z.ZodType<WebViewRequest> = z.discriminatedUnion(
   "$type",
@@ -179,6 +184,11 @@ export const WebViewRequest: z.ZodType<WebViewRequest> = z.discriminatedUnion(
       $type: z.literal("minimize"),
       id: z.string(),
       minimized: z.boolean().optional(),
+    }),
+    z.object({
+      $type: z.literal("loadHtml"),
+      html: z.string(),
+      id: z.string(),
     }),
   ],
 );


### PR DESCRIPTION
This PR depended on https://github.com/tauri-apps/wry/pull/1368 being released.

I wanted to go ahead and throw up an example as a test case. For any wry maintainers who may stumble across this issue, just clone the repo, [install deno](https://docs.deno.com/runtime/fundamentals/installation/) if you don't have it, and run `deno task example load-html` in the root. That runs the `load-html` example (as shown below) which ultimately makes a call to `WebView::load_html` in wry. 

https://github.com/zephraph/webview/blob/672c717cab0f7f373a439d0554a7582e7198043c/examples/load-html.ts#L1-L12