### PR TITLE
Fix simple example; other small tweaks

### DIFF
--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -3,6 +3,7 @@ import { createWebView } from "../src/lib.ts";
 using webview = await createWebView({
   title: "Simple",
   html: "<h1>Hello, World!</h1>",
+  devtools: true,
 });
 
 webview.on("started", async () => {

--- a/examples/tldraw.ts
+++ b/examples/tldraw.ts
@@ -27,7 +27,7 @@ const app = await esbuild.transform(tldrawApp, {
   sourcemap: false,
 });
 
-const webview = await createWebView({
+using webview = await createWebView({
   title: "TLDraw",
   html: `
     <!DOCTYPE html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use tao::window::Fullscreen;
 
+/// The version of the webview binary.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Options for creating a webview.


### PR DESCRIPTION
Simple example wasn't working because it was missing the `devtools` init flag. Want to reinforce `using` in examples for [explicit resource management](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html), and added a small docstring to the rust. 