### PR TITLE
Support window sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.0.12 (binary 0.1.10) -- 2024-09-25
+
+BREAKING CHANGES
+
+- `WebViewOptions` `accept_first_mouse` is now `acceptFirstMouse`
+- `WebViewOptions` `fullscreen` was removed in favor of `size`
+
+Additions
+
+- The webview size can be altered by providing `WebViewOptions` `size` as either `"maximized"`, `"fullscreen"`, or `{ width: number, height: number }`
+
+Misc
+
+- Tao updated to v0.30.2
+
 ## 0.0.11 (binary 0.1.9) -- 2024-09-23
 
 - Adds more doc comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.0.12 (binary 0.1.10) -- 2024-09-25
+## 0.0.12 (binary 0.1.10) -- 2024-09-26
 
 BREAKING CHANGES
 
@@ -10,10 +10,20 @@ BREAKING CHANGES
 Additions
 
 - The webview size can be altered by providing `WebViewOptions` `size` as either `"maximized"`, `"fullscreen"`, or `{ width: number, height: number }`
+- added `webview.maximize()`
+- added `webview.minimize()`
+- added `webview.fullscreen()`
+- added `webview.getSize()`
+- added `webview.setSize({ ... })`
+
+Fixes
+
+- `webview.on` and `webivew.once` had their types improved to actually return the result of their event payload
 
 Misc
 
 - Tao updated to v0.30.2
+- Wry upgraded to v0.45.0
 
 ## 0.0.11 (binary 0.1.9) -- 2024-09-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "deno-webview"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno-webview"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [profile.release]

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@justbe/webview",
   "exports": "./src/lib.ts",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "deno task gen:rust && deno task gen:deno",

--- a/examples/window-size.ts
+++ b/examples/window-size.ts
@@ -2,11 +2,35 @@ import { createWebView } from "../src/lib.ts";
 
 using webview = await createWebView({
   title: "Window Size",
-  html: "<h1>Window Size</h1>",
+  html: `
+    <h1>Window Sizes</h1>
+    <div style="display: flex; gap: 10px;">
+      <button onclick="window.ipc.postMessage('maximize')">Maximize</button>
+      <button onclick="window.ipc.postMessage('minimize')">Minimize</button>
+      <button onclick="window.ipc.postMessage('fullscreen')">Fullscreen</button>
+    </div>
+  `,
   size: {
     height: 200,
     width: 800,
   },
+  ipc: true,
+});
+
+webview.on("ipc", ({ message }) => {
+  switch (message) {
+    case "maximize":
+      webview.maximize();
+      break;
+    case "minimize":
+      webview.minimize();
+      break;
+    case "fullscreen":
+      webview.fullscreen();
+      break;
+    default:
+      console.error("Unknown message", message);
+  }
 });
 
 await webview.waitUntilClosed();

--- a/examples/window-size.ts
+++ b/examples/window-size.ts
@@ -1,0 +1,12 @@
+import { createWebView } from "../src/lib.ts";
+
+using webview = await createWebView({
+  title: "Window Size",
+  html: "<h1>Window Size</h1>",
+  size: {
+    height: 200,
+    width: 800,
+  },
+});
+
+await webview.waitUntilClosed();

--- a/schemas/WebViewMessage.json
+++ b/schemas/WebViewMessage.json
@@ -194,11 +194,11 @@
             "$type": {
               "type": "string",
               "enum": [
-                "json"
+                "boolean"
               ]
             },
             "value": {
-              "type": "string"
+              "type": "boolean"
             }
           }
         },
@@ -212,11 +212,50 @@
             "$type": {
               "type": "string",
               "enum": [
-                "boolean"
+                "float"
               ]
             },
             "value": {
-              "type": "boolean"
+              "type": "number",
+              "format": "double"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "$type",
+            "value"
+          ],
+          "properties": {
+            "$type": {
+              "type": "string",
+              "enum": [
+                "size"
+              ]
+            },
+            "value": {
+              "type": "object",
+              "required": [
+                "height",
+                "scale_factor",
+                "width"
+              ],
+              "properties": {
+                "height": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "scale_factor": {
+                  "description": "The ratio between physical and logical sizes.",
+                  "type": "number",
+                  "format": "double"
+                },
+                "width": {
+                  "type": "number",
+                  "format": "double"
+                }
+              }
             }
           }
         }

--- a/schemas/WebViewOptions.json
+++ b/schemas/WebViewOptions.json
@@ -35,7 +35,7 @@
     "title"
   ],
   "properties": {
-    "accept_first_mouse": {
+    "acceptFirstMouse": {
       "description": "Sets whether clicking an inactive window also clicks through to the webview. Default is false.",
       "default": false,
       "type": "boolean"

--- a/schemas/WebViewOptions.json
+++ b/schemas/WebViewOptions.json
@@ -65,11 +65,6 @@
       "default": false,
       "type": "boolean"
     },
-    "fullscreen": {
-      "description": "When true, the window will be fullscreen. Default is false.",
-      "default": false,
-      "type": "boolean"
-    },
     "incognito": {
       "description": "Run the WebView with incognito mode. Note that WebContext will be ingored if incognito is enabled.\n\nPlatform-specific: - Windows: Requires WebView2 Runtime version 101.0.1210.39 or higher, does nothing on older versions, see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive?tabs=dotnetcsharp#10121039",
       "default": false,
@@ -80,6 +75,17 @@
       "default": false,
       "type": "boolean"
     },
+    "size": {
+      "description": "The size of the window.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/WindowSize"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "title": {
       "description": "Sets the title of the window.",
       "type": "string"
@@ -88,6 +94,39 @@
       "description": "Sets whether the window should be transparent.",
       "default": false,
       "type": "boolean"
+    }
+  },
+  "definitions": {
+    "WindowSize": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/WindowSizeStates"
+        },
+        {
+          "type": "object",
+          "required": [
+            "height",
+            "width"
+          ],
+          "properties": {
+            "height": {
+              "type": "number",
+              "format": "double"
+            },
+            "width": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        }
+      ]
+    },
+    "WindowSizeStates": {
+      "type": "string",
+      "enum": [
+        "maximized",
+        "fullscreen"
+      ]
     }
   }
 }

--- a/schemas/WebViewRequest.json
+++ b/schemas/WebViewRequest.json
@@ -140,6 +140,144 @@
           "type": "string"
         }
       }
+    },
+    {
+      "type": "object",
+      "required": [
+        "$type",
+        "id"
+      ],
+      "properties": {
+        "$type": {
+          "type": "string",
+          "enum": [
+            "getSize"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "include_decorations": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "$type",
+        "id",
+        "size"
+      ],
+      "properties": {
+        "$type": {
+          "type": "string",
+          "enum": [
+            "setSize"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "size": {
+          "$ref": "#/definitions/SimpleSize"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "$type",
+        "id"
+      ],
+      "properties": {
+        "$type": {
+          "type": "string",
+          "enum": [
+            "fullscreen"
+          ]
+        },
+        "fullscreen": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "$type",
+        "id"
+      ],
+      "properties": {
+        "$type": {
+          "type": "string",
+          "enum": [
+            "maximize"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "maximized": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "$type",
+        "id"
+      ],
+      "properties": {
+        "$type": {
+          "type": "string",
+          "enum": [
+            "minimize"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "minimized": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
     }
-  ]
+  ],
+  "definitions": {
+    "SimpleSize": {
+      "type": "object",
+      "required": [
+        "height",
+        "width"
+      ],
+      "properties": {
+        "height": {
+          "type": "number",
+          "format": "double"
+        },
+        "width": {
+          "type": "number",
+          "format": "double"
+        }
+      }
+    }
+  }
 }

--- a/schemas/WebViewResponse.json
+++ b/schemas/WebViewResponse.json
@@ -98,11 +98,11 @@
             "$type": {
               "type": "string",
               "enum": [
-                "json"
+                "boolean"
               ]
             },
             "value": {
-              "type": "string"
+              "type": "boolean"
             }
           }
         },
@@ -116,11 +116,50 @@
             "$type": {
               "type": "string",
               "enum": [
-                "boolean"
+                "float"
               ]
             },
             "value": {
-              "type": "boolean"
+              "type": "number",
+              "format": "double"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "$type",
+            "value"
+          ],
+          "properties": {
+            "$type": {
+              "type": "string",
+              "enum": [
+                "size"
+              ]
+            },
+            "value": {
+              "type": "object",
+              "required": [
+                "height",
+                "scale_factor",
+                "width"
+              ],
+              "properties": {
+                "height": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "scale_factor": {
+                  "description": "The ratio between physical and logical sizes.",
+                  "type": "number",
+                  "format": "double"
+                },
+                "width": {
+                  "type": "number",
+                  "format": "double"
+                }
+              }
             }
           }
         }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -370,12 +370,16 @@ export class WebView implements Disposable {
    */
   async getSize(
     includeDecorations?: boolean,
-  ): Promise<{ width: number; height: number }> {
+  ): Promise<{ width: number; height: number; scaleFactor: number }> {
     const result = await this.#send({
       $type: "getSize",
       include_decorations: includeDecorations,
     });
-    return returnResult(result, "size");
+    const { width, height, scale_factor: scaleFactor } = returnResult(
+      result,
+      "size",
+    );
+    return { width, height, scaleFactor };
   }
 
   /**

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -53,54 +53,36 @@ type WebViewNotification = Extract<
   { $type: "notification" }
 >["data"];
 
-type ResultType = Extract<WebViewResponse, { $type: "result" }>["result"];
-type ResultKinds = Pick<ResultType, "$type">["$type"];
+type ResultType = Extract<WebViewResponse, { $type: "result" }>;
 
 /**
  * A helper function for extracting the result from a webview response.
+ * Throws if the response includes unexpected results.
  *
  * @param result - The result of the webview request.
  * @param expectedType - The format of the expected result.
  */
-function returnResult(
-  result: WebViewResponse,
-  expectedType: "boolean",
-): boolean;
-function returnResult(
-  result: WebViewResponse,
-  expectedType: "string",
-): string;
-function returnResult(
-  result: WebViewResponse,
-  expectedType: "json",
-): JSON;
-function returnResult(
-  result: WebViewResponse,
-  expectedType?: ResultKinds,
-): string | JSON | boolean {
-  switch (result.$type) {
-    case "result": {
-      if (expectedType && result.result.$type !== expectedType) {
-        throw new Error(`unexpected result type: ${result.result.$type}`);
-      }
-      const res = result.result;
-      switch (res.$type) {
-        case "string":
-          return res.value;
-        case "json":
-          return JSON.parse(res.value) as JSON;
-        case "boolean":
-          return res.value;
-      }
-      break;
+function returnResult<
+  Response extends WebViewResponse,
+  E extends ResultType["result"]["$type"],
+>(
+  result: Response,
+  expectedType: E,
+): Extract<ResultType["result"], { $type: E }>["value"] {
+  if (result.$type === "result") {
+    if (result.result.$type === expectedType) {
+      // @ts-expect-error TS doesn't correctly narrow this type, but it's correct
+      return result.result.value;
     }
-    case "err":
-      throw new Error(result.message);
-    default:
-      throw new Error(`unexpected response: ${result.$type}`);
+    throw new Error(`unexpected result type: ${result.result.$type}`);
   }
+  throw new Error(`unexpected response: ${result.$type}`);
 }
 
+/**
+ * A helper function for acknowledging a webview response.
+ * Throws if the response includes unexpected results.
+ */
 const returnAck = (result: WebViewResponse) => {
   switch (result.$type) {
     case "ack":
@@ -367,6 +349,63 @@ export class WebView implements Disposable {
   async getVersion(): Promise<string> {
     const result = await this.#send({ $type: "getVersion" });
     return returnResult(result, "string");
+  }
+
+  /**
+   * Sets the size of the webview window.
+   *
+   * Note: this is the logical size of the window, not the physical size.
+   * @see https://docs.rs/dpi/0.1.1/x86_64-unknown-linux-gnu/dpi/index.html#position-and-size-types
+   */
+  async setSize(size: { width: number; height: number }): Promise<void> {
+    const result = await this.#send({ $type: "setSize", size });
+    return returnAck(result);
+  }
+
+  /**
+   * Gets the size of the webview window.
+   *
+   * Note: this is the logical size of the window, not the physical size.
+   * @see https://docs.rs/dpi/0.1.1/x86_64-unknown-linux-gnu/dpi/index.html#position-and-size-types
+   */
+  async getSize(
+    includeDecorations?: boolean,
+  ): Promise<{ width: number; height: number }> {
+    const result = await this.#send({
+      $type: "getSize",
+      include_decorations: includeDecorations,
+    });
+    return returnResult(result, "size");
+  }
+
+  /**
+   * Enters or exits fullscreen mode for the webview.
+   *
+   * @param fullscreen - If true, the webview will enter fullscreen mode. If false, the webview will exit fullscreen mode. If not specified, the webview will toggle fullscreen mode.
+   */
+  async fullscreen(fullscreen?: boolean): Promise<void> {
+    const result = await this.#send({ $type: "fullscreen", fullscreen });
+    return returnAck(result);
+  }
+
+  /**
+   * Maximizes or unmaximizes the webview window.
+   *
+   * @param maximized - If true, the webview will be maximized. If false, the webview will be unmaximized. If not specified, the webview will toggle maximized state.
+   */
+  async maximize(maximized?: boolean): Promise<void> {
+    const result = await this.#send({ $type: "maximize", maximized });
+    return returnAck(result);
+  }
+
+  /**
+   * Minimizes or unminimizes the webview window.
+   *
+   * @param minimized - If true, the webview will be minimized. If false, the webview will be unminimized. If not specified, the webview will toggle minimized state.
+   */
+  async minimize(minimized?: boolean): Promise<void> {
+    const result = await this.#send({ $type: "minimize", minimized });
+    return returnAck(result);
   }
 
   /**

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,7 +38,7 @@ export type { WebViewOptions } from "./schemas.ts";
 
 // Should match the cargo package version
 /** The version of the webview binary that's expected */
-export const BIN_VERSION = "0.1.9";
+export const BIN_VERSION = "0.1.10";
 
 type JSON =
   | string

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Options for creating a webview.
 #[derive(JsonSchema, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 struct WebViewOptions {
     /// Sets the title of the window.
     title: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,13 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(JsonSchema, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+struct SimpleSize {
+    width: f64,
+    height: f64,
+}
+
+#[derive(JsonSchema, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 enum WindowSizeStates {
     Maximized,
     Fullscreen,
@@ -112,13 +119,51 @@ enum Notification {
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type")]
 enum Request {
-    GetVersion { id: String },
-    Eval { id: String, js: String },
-    SetTitle { id: String, title: String },
-    GetTitle { id: String },
-    SetVisibility { id: String, visible: bool },
-    IsVisible { id: String },
-    OpenDevTools { id: String },
+    GetVersion {
+        id: String,
+    },
+    Eval {
+        id: String,
+        js: String,
+    },
+    SetTitle {
+        id: String,
+        title: String,
+    },
+    GetTitle {
+        id: String,
+    },
+    SetVisibility {
+        id: String,
+        visible: bool,
+    },
+    IsVisible {
+        id: String,
+    },
+    OpenDevTools {
+        id: String,
+    },
+    GetSize {
+        id: String,
+        #[serde(default)]
+        include_decorations: Option<bool>,
+    },
+    SetSize {
+        id: String,
+        size: SimpleSize,
+    },
+    Fullscreen {
+        id: String,
+        fullscreen: Option<bool>,
+    },
+    Maximize {
+        id: String,
+        maximized: Option<bool>,
+    },
+    Minimize {
+        id: String,
+        minimized: Option<bool>,
+    },
 }
 
 /// Responses from the webview to the client.
@@ -138,8 +183,14 @@ enum Response {
 #[allow(dead_code)]
 enum ResultType {
     String(String),
-    Json(String),
     Boolean(bool),
+    Float(f64),
+    Size {
+        width: f64,
+        height: f64,
+        /// The ratio between physical and logical sizes.
+        scale_factor: f64,
+    },
 }
 
 impl From<String> for ResultType {
@@ -327,6 +378,53 @@ fn main() -> wry::Result<()> {
                                 id,
                                 result: VERSION.to_string().into(),
                             });
+                        }
+                        Request::GetSize {
+                            id,
+                            include_decorations,
+                        } => {
+                            let size = if include_decorations.unwrap_or(false) {
+                                window.outer_size().to_logical(window.scale_factor())
+                            } else {
+                                window.inner_size().to_logical(window.scale_factor())
+                            };
+                            res(Response::Result {
+                                id,
+                                result: ResultType::Size {
+                                    width: size.width,
+                                    height: size.height,
+                                    scale_factor: window.scale_factor(),
+                                },
+                            });
+                        }
+                        Request::SetSize { id, size } => {
+                            window.set_inner_size(Size::Logical(LogicalSize::new(
+                                size.width,
+                                size.height,
+                            )));
+                            res(Response::Ack { id });
+                        }
+                        Request::Fullscreen { id, fullscreen } => {
+                            let fullscreen = fullscreen.unwrap_or(!window.fullscreen().is_some());
+                            eprintln!("Fullscreen: {:?}", fullscreen);
+                            if fullscreen {
+                                window.set_fullscreen(Some(Fullscreen::Borderless(None)));
+                            } else {
+                                window.set_fullscreen(None);
+                            }
+                            res(Response::Ack { id });
+                        }
+                        Request::Maximize { id, maximized } => {
+                            let maximized = maximized.unwrap_or(!window.is_maximized());
+                            eprintln!("Maximize: {:?}", maximized);
+                            window.set_maximized(maximized);
+                            res(Response::Ack { id });
+                        }
+                        Request::Minimize { id, minimized } => {
+                            let minimized = minimized.unwrap_or(!window.is_minimized());
+                            eprintln!("Minimize: {:?}", minimized);
+                            window.set_minimized(minimized);
+                            res(Response::Ack { id });
                         }
                     }
                 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7,7 +7,7 @@ import { z } from "npm:zod";
 export type WebViewOptions =
   & {
     /** Sets whether clicking an inactive window also clicks through to the webview. Default is false. */
-    accept_first_mouse?: boolean;
+    acceptFirstMouse?: boolean;
     /** When true, all media can be played without user interaction. Default is false. */
     autoplay?: boolean;
     /**
@@ -51,7 +51,7 @@ export type WebViewOptions =
   );
 export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
   z.object({
-    accept_first_mouse: z.boolean().optional(),
+    acceptFirstMouse: z.boolean().optional(),
     autoplay: z.boolean().optional(),
     clipboard: z.boolean().optional(),
     decorations: z.boolean().optional(),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -108,6 +108,34 @@ export type WebViewRequest =
   | {
     $type: "openDevTools";
     id: string;
+  }
+  | {
+    $type: "getSize";
+    id: string;
+    include_decorations?: boolean;
+  }
+  | {
+    $type: "setSize";
+    id: string;
+    size: {
+      height: number;
+      width: number;
+    };
+  }
+  | {
+    $type: "fullscreen";
+    fullscreen?: boolean;
+    id: string;
+  }
+  | {
+    $type: "maximize";
+    id: string;
+    maximized?: boolean;
+  }
+  | {
+    $type: "minimize";
+    id: string;
+    minimized?: boolean;
   };
 export const WebViewRequest: z.ZodType<WebViewRequest> = z.discriminatedUnion(
   "$type",
@@ -127,6 +155,31 @@ export const WebViewRequest: z.ZodType<WebViewRequest> = z.discriminatedUnion(
     }),
     z.object({ $type: z.literal("isVisible"), id: z.string() }),
     z.object({ $type: z.literal("openDevTools"), id: z.string() }),
+    z.object({
+      $type: z.literal("getSize"),
+      id: z.string(),
+      include_decorations: z.boolean().optional(),
+    }),
+    z.object({
+      $type: z.literal("setSize"),
+      id: z.string(),
+      size: z.object({ height: z.number(), width: z.number() }),
+    }),
+    z.object({
+      $type: z.literal("fullscreen"),
+      fullscreen: z.boolean().optional(),
+      id: z.string(),
+    }),
+    z.object({
+      $type: z.literal("maximize"),
+      id: z.string(),
+      maximized: z.boolean().optional(),
+    }),
+    z.object({
+      $type: z.literal("minimize"),
+      id: z.string(),
+      minimized: z.boolean().optional(),
+    }),
   ],
 );
 
@@ -147,12 +200,20 @@ export type WebViewResponse =
         value: string;
       }
       | {
-        $type: "json";
-        value: string;
-      }
-      | {
         $type: "boolean";
         value: boolean;
+      }
+      | {
+        $type: "float";
+        value: number;
+      }
+      | {
+        $type: "size";
+        value: {
+          height: number;
+          scale_factor: number;
+          width: number;
+        };
       };
   }
   | {
@@ -169,8 +230,16 @@ export const WebViewResponse: z.ZodType<WebViewResponse> = z.discriminatedUnion(
       id: z.string(),
       result: z.discriminatedUnion("$type", [
         z.object({ $type: z.literal("string"), value: z.string() }),
-        z.object({ $type: z.literal("json"), value: z.string() }),
         z.object({ $type: z.literal("boolean"), value: z.boolean() }),
+        z.object({ $type: z.literal("float"), value: z.number() }),
+        z.object({
+          $type: z.literal("size"),
+          value: z.object({
+            height: z.number(),
+            scale_factor: z.number(),
+            width: z.number(),
+          }),
+        }),
       ]),
     }),
     z.object({ $type: z.literal("err"), id: z.string(), message: z.string() }),
@@ -212,12 +281,20 @@ export type WebViewMessage =
             value: string;
           }
           | {
-            $type: "json";
-            value: string;
-          }
-          | {
             $type: "boolean";
             value: boolean;
+          }
+          | {
+            $type: "float";
+            value: number;
+          }
+          | {
+            $type: "size";
+            value: {
+              height: number;
+              scale_factor: number;
+              width: number;
+            };
           };
       }
       | {
@@ -246,8 +323,16 @@ export const WebViewMessage: z.ZodType<WebViewMessage> = z.discriminatedUnion(
           id: z.string(),
           result: z.discriminatedUnion("$type", [
             z.object({ $type: z.literal("string"), value: z.string() }),
-            z.object({ $type: z.literal("json"), value: z.string() }),
             z.object({ $type: z.literal("boolean"), value: z.boolean() }),
+            z.object({ $type: z.literal("float"), value: z.number() }),
+            z.object({
+              $type: z.literal("size"),
+              value: z.object({
+                height: z.number(),
+                scale_factor: z.number(),
+                width: z.number(),
+              }),
+            }),
           ]),
         }),
         z.object({

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -26,8 +26,6 @@ export type WebViewOptions =
     devtools?: boolean;
     /** Sets whether the webview should be focused when created. Default is false. */
     focused?: boolean;
-    /** When true, the window will be fullscreen. Default is false. */
-    fullscreen?: boolean;
     /**
      * Run the WebView with incognito mode. Note that WebContext will be ingored if incognito is enabled.
      *
@@ -36,6 +34,11 @@ export type WebViewOptions =
     incognito?: boolean;
     /** Sets whether host should be able to receive messages from the webview via `window.ipc.postMessage`. */
     ipc?: boolean;
+    /** The size of the window. */
+    size?: "maximized" | "fullscreen" | {
+      height: number;
+      width: number;
+    };
     /** Sets the title of the window. */
     title: string;
     /** Sets whether the window should be transparent. */
@@ -57,9 +60,14 @@ export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
     decorations: z.boolean().optional(),
     devtools: z.boolean().optional(),
     focused: z.boolean().optional(),
-    fullscreen: z.boolean().optional(),
     incognito: z.boolean().optional(),
     ipc: z.boolean().optional(),
+    size: z.union([
+      z.literal("maximized"),
+      z.literal("fullscreen"),
+      z.object({ height: z.number(), width: z.number() }),
+    ])
+      .optional(),
     title: z.string(),
     transparent: z.boolean().optional(),
   }),


### PR DESCRIPTION
Allows the creation of webviews at different sizings. 

```typescript
await createWebView({
  title: "Window Size",
  html: "<h1>Window Size</h1>",
  size: {
    height: 200,
    width: 800,
  },
});

await createWebView({
  title: "Window Size",
  html: "<h1>Window Size</h1>",
  size: "fullscreen",
});

await createWebView({
  title: "Window Size",
  html: "<h1>Window Size</h1>",
  size: "maximized",
});
```

Allow allows window sizes to be changed after initialization.

```typescript
// Each of these can be called again to toggle, or you can pass in a boolean value to enable/disable it. 
await webview.fullscreen();
await webview.minimize();
await webview.maximize();

await webview.setSize({
    height: 200,
    width: 800,
})

// pass true to include the border and title bar in the resultant size
// scaleFactor is a multiplier to determine the number of physical pixels for width/height
const { width, height, scaleFactor } = await webview.getSize()
```