### PR TITLE
Improve IPC types; throw if ipc not enabled

### DIFF
--- a/examples/ipc.ts
+++ b/examples/ipc.ts
@@ -7,7 +7,6 @@ using webview = await createWebView({
   ipc: true,
 });
 
-// @ts-expect-error event emitter types still need to be corrected
 webview.on("ipc", ({ message }) => {
   console.log(message);
 });


### PR DESCRIPTION
Improve the event types so that the IPC message types work as expected for `webview.on("ipc", { message }, ...`

If listening to IPC but IPC isn't enabled throw an error. I may downgrade this later to a warning.