### PR TITLE
Use a custom protocol when loading HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.0.15 (binary 0.1.12) -- 2024-09-28
+
+- Pages loaded with `html` are now considered to be in a secure context.
+- When creating a webview with `html` or calling `webview.loadHtml()` the webview now has a default origin which can be changed via the `origin` parameter
+- Improved type generation to output more doc strings and documented more code
+- Update TLDraw example with a persistence key
+
 ## 0.0.14 (binary 0.1.11) -- 2024-09-26
 
 - fix an issue where arm64 macs weren't downloading the correct binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "deno-webview"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno-webview"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 
 [profile.release]

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@justbe/webview",
   "exports": "./src/lib.ts",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "deno task gen:rust && deno task gen:deno",

--- a/examples/load-html.ts
+++ b/examples/load-html.ts
@@ -3,9 +3,16 @@ import { createWebView } from "../src/lib.ts";
 using webview = await createWebView({
   title: "Load Html Example",
   html: "<h1>Initial html</h1>",
+  // Note: This origin is used with a custom protocol so it doesn't match
+  // https://example.com. This doesn't need to be set, but can be useful if
+  // you want to control resources that are scoped to a specific origin like
+  // local storage or indexeddb.
+  origin: "example.com",
+  devtools: true,
 });
 
 webview.on("started", async () => {
+  await webview.openDevTools();
   await webview.loadHtml("<h1>Updated html!</h1>");
 });
 

--- a/examples/tldraw.ts
+++ b/examples/tldraw.ts
@@ -9,7 +9,7 @@ function App() {
   return (
     <>
       <div style={{ position: "absolute", inset: 0 }}>
-        <Tldraw cameraOptions={{ wheelBehavior: "zoom" }} />
+        <Tldraw persistenceKey="tldraw-example" cameraOptions={{ wheelBehavior: "zoom" }} />
       </div>
     </>
   );

--- a/schemas/WebViewMessage.json
+++ b/schemas/WebViewMessage.json
@@ -58,6 +58,7 @@
               ]
             },
             "version": {
+              "description": "The version of the webview binary",
               "type": "string"
             }
           }
@@ -76,6 +77,7 @@
               ]
             },
             "message": {
+              "description": "The message sent from the webview UI to the client.",
               "type": "string"
             }
           }
@@ -243,6 +245,7 @@
               ],
               "properties": {
                 "height": {
+                  "description": "The height of the window in logical pixels.",
                   "type": "number",
                   "format": "double"
                 },
@@ -252,6 +255,7 @@
                   "format": "double"
                 },
                 "width": {
+                  "description": "The width of the window in logical pixels.",
                   "type": "number",
                   "format": "double"
                 }

--- a/schemas/WebViewOptions.json
+++ b/schemas/WebViewOptions.json
@@ -3,32 +3,35 @@
   "title": "WebViewOptions",
   "description": "Options for creating a webview.",
   "type": "object",
-  "oneOf": [
+  "anyOf": [
     {
-      "description": "Url to load in the webview.",
       "type": "object",
       "required": [
         "url"
       ],
       "properties": {
         "url": {
+          "description": "Url to load in the webview. Note: Don't use data URLs here, as they are not supported. Use the `html` field instead.",
           "type": "string"
         }
-      },
-      "additionalProperties": false
+      }
     },
     {
-      "description": "Html to load in the webview.",
       "type": "object",
       "required": [
         "html"
       ],
       "properties": {
         "html": {
+          "description": "Html to load in the webview.",
+          "type": "string"
+        },
+        "origin": {
+          "description": "What to set as the origin of the webview when loading html.",
+          "default": "init",
           "type": "string"
         }
-      },
-      "additionalProperties": false
+      }
     }
   ],
   "required": [

--- a/schemas/WebViewRequest.json
+++ b/schemas/WebViewRequest.json
@@ -17,6 +17,7 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         }
       }
@@ -36,9 +37,11 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         },
         "js": {
+          "description": "The javascript to evaluate.",
           "type": "string"
         }
       }
@@ -58,9 +61,11 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         },
         "title": {
+          "description": "The title to set.",
           "type": "string"
         }
       }
@@ -79,6 +84,7 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         }
       }
@@ -98,9 +104,11 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         },
         "visible": {
+          "description": "Whether the window should be visible or hidden.",
           "type": "boolean"
         }
       }
@@ -119,6 +127,7 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         }
       }
@@ -137,6 +146,7 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         }
       }
@@ -155,9 +165,11 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         },
         "include_decorations": {
+          "description": "Whether to include the title bar and borders in the size measurement.",
           "default": null,
           "type": [
             "boolean",
@@ -181,10 +193,16 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         },
         "size": {
-          "$ref": "#/definitions/SimpleSize"
+          "description": "The size to set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SimpleSize"
+            }
+          ]
         }
       }
     },
@@ -202,12 +220,14 @@
           ]
         },
         "fullscreen": {
+          "description": "Whether to enter fullscreen mode. If left unspecified, the window will enter fullscreen mode if it is not already in fullscreen mode or exit fullscreen mode if it is currently in fullscreen mode.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         }
       }
@@ -226,9 +246,11 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         },
         "maximized": {
+          "description": "Whether to maximize the window. If left unspecified, the window will be maximized if it is not already maximized or restored if it was previously maximized.",
           "type": [
             "boolean",
             "null"
@@ -250,9 +272,11 @@
           ]
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
         },
         "minimized": {
+          "description": "Whether to minimize the window. If left unspecified, the window will be minimized if it is not already minimized or restored if it was previously minimized.",
           "type": [
             "boolean",
             "null"
@@ -275,10 +299,19 @@
           ]
         },
         "html": {
+          "description": "HTML to set as the content of the webview.",
           "type": "string"
         },
         "id": {
+          "description": "The id of the request.",
           "type": "string"
+        },
+        "origin": {
+          "description": "What to set as the origin of the webview when loading html. If not specified, the origin will be set to the value of the `origin` field when the webview was created.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }

--- a/schemas/WebViewResponse.json
+++ b/schemas/WebViewResponse.json
@@ -147,6 +147,7 @@
               ],
               "properties": {
                 "height": {
+                  "description": "The height of the window in logical pixels.",
                   "type": "number",
                   "format": "double"
                 },
@@ -156,6 +157,7 @@
                   "format": "double"
                 },
                 "width": {
+                  "description": "The width of the window in logical pixels.",
                   "type": "number",
                   "format": "double"
                 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,7 +38,7 @@ export type { WebViewOptions } from "./schemas.ts";
 
 // Should match the cargo package version
 /** The version of the webview binary that's expected */
-export const BIN_VERSION = "0.1.11";
+export const BIN_VERSION = "0.1.12";
 
 type JSON =
   | string

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -46,10 +46,14 @@ export type WebViewOptions =
   }
   & (
     | {
+      /** Url to load in the webview. Note: Don't use data URLs here, as they are not supported. Use the `html` field instead. */
       url: string;
     }
     | {
+      /** Html to load in the webview. */
       html: string;
+      /** What to set as the origin of the webview when loading html. */
+      origin?: string;
     }
   );
 export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
@@ -71,7 +75,10 @@ export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
     title: z.string(),
     transparent: z.boolean().optional(),
   }),
-  z.union([z.object({ url: z.string() }), z.object({ html: z.string() })]),
+  z.union([
+    z.object({ url: z.string() }),
+    z.object({ html: z.string(), origin: z.string().optional() }),
+  ]),
 );
 
 /**
@@ -80,43 +87,57 @@ export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
 export type WebViewRequest =
   | {
     $type: "getVersion";
+    /** The id of the request. */
     id: string;
   }
   | {
     $type: "eval";
+    /** The id of the request. */
     id: string;
+    /** The javascript to evaluate. */
     js: string;
   }
   | {
     $type: "setTitle";
+    /** The id of the request. */
     id: string;
+    /** The title to set. */
     title: string;
   }
   | {
     $type: "getTitle";
+    /** The id of the request. */
     id: string;
   }
   | {
     $type: "setVisibility";
+    /** The id of the request. */
     id: string;
+    /** Whether the window should be visible or hidden. */
     visible: boolean;
   }
   | {
     $type: "isVisible";
+    /** The id of the request. */
     id: string;
   }
   | {
     $type: "openDevTools";
+    /** The id of the request. */
     id: string;
   }
   | {
     $type: "getSize";
+    /** The id of the request. */
     id: string;
+    /** Whether to include the title bar and borders in the size measurement. */
     include_decorations?: boolean;
   }
   | {
     $type: "setSize";
+    /** The id of the request. */
     id: string;
+    /** The size to set. */
     size: {
       height: number;
       width: number;
@@ -124,23 +145,33 @@ export type WebViewRequest =
   }
   | {
     $type: "fullscreen";
+    /** Whether to enter fullscreen mode. If left unspecified, the window will enter fullscreen mode if it is not already in fullscreen mode or exit fullscreen mode if it is currently in fullscreen mode. */
     fullscreen?: boolean;
+    /** The id of the request. */
     id: string;
   }
   | {
     $type: "maximize";
+    /** The id of the request. */
     id: string;
+    /** Whether to maximize the window. If left unspecified, the window will be maximized if it is not already maximized or restored if it was previously maximized. */
     maximized?: boolean;
   }
   | {
     $type: "minimize";
+    /** The id of the request. */
     id: string;
+    /** Whether to minimize the window. If left unspecified, the window will be minimized if it is not already minimized or restored if it was previously minimized. */
     minimized?: boolean;
   }
   | {
     $type: "loadHtml";
+    /** HTML to set as the content of the webview. */
     html: string;
+    /** The id of the request. */
     id: string;
+    /** What to set as the origin of the webview when loading html. If not specified, the origin will be set to the value of the `origin` field when the webview was created. */
+    origin?: string;
   };
 export const WebViewRequest: z.ZodType<WebViewRequest> = z.discriminatedUnion(
   "$type",
@@ -189,6 +220,7 @@ export const WebViewRequest: z.ZodType<WebViewRequest> = z.discriminatedUnion(
       $type: z.literal("loadHtml"),
       html: z.string(),
       id: z.string(),
+      origin: z.string().optional(),
     }),
   ],
 );
@@ -220,8 +252,11 @@ export type WebViewResponse =
       | {
         $type: "size";
         value: {
+          /** The height of the window in logical pixels. */
           height: number;
+          /** The ratio between physical and logical sizes. */
           scale_factor: number;
+          /** The width of the window in logical pixels. */
           width: number;
         };
       };
@@ -265,10 +300,12 @@ export type WebViewMessage =
     data:
       | {
         $type: "started";
+        /** The version of the webview binary */
         version: string;
       }
       | {
         $type: "ipc";
+        /** The message sent from the webview UI to the client. */
         message: string;
       }
       | {
@@ -301,8 +338,11 @@ export type WebViewMessage =
           | {
             $type: "size";
             value: {
+              /** The height of the window in logical pixels. */
               height: number;
+              /** The ratio between physical and logical sizes. */
               scale_factor: number;
+              /** The width of the window in logical pixels. */
               width: number;
             };
           };


### PR DESCRIPTION
Fixes #70 

When I first reported https://github.com/tauri-apps/wry/issues/1367, @amrbashir recommended I use a custom protocol instead of `with_html`. I hadn't experimented enough with custom protocols at the time and didn't real understand the tradeoffs between that an `with_html`. The challenge with using `with_html` is that the `origin` is _null_ which means the page is considered to be in an insecure context. That disables a lot of features (like clipboard, noted in #70). The other challenge with `with_html` is that when you reload you lose the contents of the page (which is what https://github.com/tauri-apps/wry/issues/1367 was all about). I'd implemented `load_html` in https://github.com/tauri-apps/wry/issues/1368, but that really doesn't get around the other problems of `with_html`. 

This PR implements a custom protocol called `load-html://`. The request itself is ignored, it's just used to trigger the protocol load. There's a `RefCell` in the scope of the process where the HTML is cached. When the webview is initialized with `html`, that initial HTML string is loaded into the ref cell and the webview is initialized with the url `load-html://init`. Likewise, when `webview.loadHtml` is called, it sets the refcell and loads `load-html://load/<id>`. 