### PR TITLE
Add `initializationScript`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.16 (binary 0.1.13) -- 2024-09-29
+
+- Add `initializationScript` to `WebViewOptions`. Allows providing JS that runs before `onLoad`.
+
 ## 0.0.15 (binary 0.1.12) -- 2024-09-28
 
 - Pages loaded with `html` are now considered to be in a secure context.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "deno-webview"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno-webview"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 
 [profile.release]

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@justbe/webview",
   "exports": "./src/lib.ts",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "deno task gen:rust && deno task gen:deno",

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -4,6 +4,8 @@ using webview = await createWebView({
   title: "Simple",
   html: "<h1>Hello, World!</h1>",
   devtools: true,
+  initializationScript:
+    "console.log('This is printed from initializationScript!')",
 });
 
 webview.on("started", async () => {

--- a/schemas/WebViewOptions.json
+++ b/schemas/WebViewOptions.json
@@ -73,6 +73,14 @@
       "default": false,
       "type": "boolean"
     },
+    "initializationScript": {
+      "description": "Run JavaScript code when loading new pages. When the webview loads a new page, this code will be executed. It is guaranteed that the code is executed before window.onload.",
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "ipc": {
       "description": "Sets whether host should be able to receive messages from the webview via `window.ipc.postMessage`.",
       "default": false,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,15 +38,7 @@ export type { WebViewOptions } from "./schemas.ts";
 
 // Should match the cargo package version
 /** The version of the webview binary that's expected */
-export const BIN_VERSION = "0.1.12";
-
-type JSON =
-  | string
-  | number
-  | boolean
-  | null
-  | JSON[]
-  | { [key: string]: JSON };
+export const BIN_VERSION = "0.1.13";
 
 type WebViewNotification = Extract<
   WebViewMessage,

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,9 @@ struct WebViewOptions {
     /// Sets whether host should be able to receive messages from the webview via `window.ipc.postMessage`.
     #[serde(default)]
     ipc: bool,
+    #[serde(default)]
+    /// Run JavaScript code when loading new pages. When the webview loads a new page, this code will be executed. It is guaranteed that the code is executed before window.onload.
+    initialization_script: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -338,6 +341,10 @@ fn main() -> wry::Result<()> {
                 }))
                 .unwrap()
         })
+    }
+    if let Some(initialization_script) = webview_options.initialization_script {
+        webview_builder =
+            webview_builder.with_initialization_script(initialization_script.as_str());
     }
     let webview = webview_builder.build()?;
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -32,6 +32,8 @@ export type WebViewOptions =
      * Platform-specific: - Windows: Requires WebView2 Runtime version 101.0.1210.39 or higher, does nothing on older versions, see https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive?tabs=dotnetcsharp#10121039
      */
     incognito?: boolean;
+    /** Run JavaScript code when loading new pages. When the webview loads a new page, this code will be executed. It is guaranteed that the code is executed before window.onload. */
+    initializationScript?: string;
     /** Sets whether host should be able to receive messages from the webview via `window.ipc.postMessage`. */
     ipc?: boolean;
     /** The size of the window. */
@@ -65,6 +67,7 @@ export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
     devtools: z.boolean().optional(),
     focused: z.boolean().optional(),
     incognito: z.boolean().optional(),
+    initializationScript: z.string().optional(),
     ipc: z.boolean().optional(),
     size: z.union([
       z.literal("maximized"),


### PR DESCRIPTION
Adds the `initializationScript` option to `WebViewOptions`. This allows passing a JS string that's executed inside the webview before `onLoad` has been called. 