### PR TITLE
Only run publish after release has finished

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   workflow_run:
-    workflows: ["Verify"]
+    workflows: ["Verify", "Release Rust Binary"]
     types:
       - completed
     branches: [main]


### PR DESCRIPTION
Fixes #65 

This updates the release process so that the JSR publish on triggers _after_ the binary release has completed. This ensures people who upgrade immediately don't have a period of time where the binary request fails because it's not out yet. 