### PR TITLE
Add `.loadUrl`, support for headers, support for userAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.17 (binary 0.1.14) -- 2024-10-02
+
+- Add `webview.loadUrl` to load a new URL after the webview is initialized
+- Add the ability to specify headers when instantiating a webview with a URL
+- Add `userAgent` to `WebViewOptions` to construct a new webview with a custom user agent.
+
 ## 0.0.16 (binary 0.1.13) -- 2024-09-29
 
 - Add `initializationScript` to `WebViewOptions`. Allows providing JS that runs before `onLoad`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "deno-webview"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno-webview"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 
 [profile.release]

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@justbe/webview",
   "exports": "./src/lib.ts",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "gen": "deno task gen:rust && deno task gen:deno",

--- a/examples/load-url.ts
+++ b/examples/load-url.ts
@@ -1,0 +1,24 @@
+import { createWebView } from "../src/lib.ts";
+
+using webview = await createWebView({
+  title: "Load Url Example",
+  url: "https://example.com",
+  headers: {
+    "Content-Type": "text/html",
+  },
+  devtools: true,
+});
+
+webview.on("started", async () => {
+  await webview.openDevTools();
+  await sleep(2000);
+  await webview.loadUrl("https://val.town/", {
+    "Content-Type": "text/html",
+  });
+});
+
+await webview.waitUntilClosed();
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/examples/load-url.ts
+++ b/examples/load-url.ts
@@ -6,6 +6,7 @@ using webview = await createWebView({
   headers: {
     "Content-Type": "text/html",
   },
+  userAgent: "curl/7.81.0",
   devtools: true,
 });
 

--- a/schemas/WebViewOptions.json
+++ b/schemas/WebViewOptions.json
@@ -115,6 +115,14 @@
       "description": "Sets whether the window should be transparent.",
       "default": false,
       "type": "boolean"
+    },
+    "userAgent": {
+      "description": "Sets the user agent to use when loading pages.",
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "definitions": {

--- a/schemas/WebViewOptions.json
+++ b/schemas/WebViewOptions.json
@@ -10,6 +10,16 @@
         "url"
       ],
       "properties": {
+        "headers": {
+          "description": "Optional headers to send with the request.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "url": {
           "description": "Url to load in the webview. Note: Don't use data URLs here, as they are not supported. Use the `html` field instead.",
           "type": "string"

--- a/schemas/WebViewRequest.json
+++ b/schemas/WebViewRequest.json
@@ -314,6 +314,40 @@
           ]
         }
       }
+    },
+    {
+      "type": "object",
+      "required": [
+        "$type",
+        "id",
+        "url"
+      ],
+      "properties": {
+        "$type": {
+          "type": "string",
+          "enum": [
+            "loadUrl"
+          ]
+        },
+        "headers": {
+          "description": "Optional headers to send with the request.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "The id of the request.",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL to load in the webview.",
+          "type": "string"
+        }
+      }
     }
   ],
   "definitions": {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,7 +38,7 @@ export type { WebViewOptions } from "./schemas.ts";
 
 // Should match the cargo package version
 /** The version of the webview binary that's expected */
-export const BIN_VERSION = "0.1.13";
+export const BIN_VERSION = "0.1.14";
 
 type WebViewNotification = Extract<
   WebViewMessage,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -464,6 +464,14 @@ export class WebView implements Disposable {
   }
 
   /**
+   * Loads a URL in the webview.
+   */
+  async loadUrl(url: string, headers?: Record<string, string>): Promise<void> {
+    const result = await this.#send({ $type: "loadUrl", url, headers });
+    return returnAck(result);
+  }
+
+  /**
    * Destroys the webview and cleans up resources.
    *
    * Alternatively you can use the disposible interface.

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,9 @@ struct WebViewOptions {
     #[serde(default)]
     /// Run JavaScript code when loading new pages. When the webview loads a new page, this code will be executed. It is guaranteed that the code is executed before window.onload.
     initialization_script: Option<String>,
+    /// Sets the user agent to use when loading pages.
+    #[serde(default)]
+    user_agent: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -373,6 +376,9 @@ fn main() -> wry::Result<()> {
     if let Some(initialization_script) = webview_options.initialization_script {
         webview_builder =
             webview_builder.with_initialization_script(initialization_script.as_str());
+    }
+    if let Some(user_agent) = webview_options.user_agent {
+        webview_builder = webview_builder.with_user_agent(user_agent.as_str());
     }
     let webview = webview_builder.build()?;
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -48,6 +48,8 @@ export type WebViewOptions =
   }
   & (
     | {
+      /** Optional headers to send with the request. */
+      headers?: Record<string, string>;
       /** Url to load in the webview. Note: Don't use data URLs here, as they are not supported. Use the `html` field instead. */
       url: string;
     }
@@ -79,7 +81,10 @@ export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
     transparent: z.boolean().optional(),
   }),
   z.union([
-    z.object({ url: z.string() }),
+    z.object({
+      headers: z.record(z.string(), z.string()).optional(),
+      url: z.string(),
+    }),
     z.object({ html: z.string(), origin: z.string().optional() }),
   ]),
 );
@@ -175,6 +180,15 @@ export type WebViewRequest =
     id: string;
     /** What to set as the origin of the webview when loading html. If not specified, the origin will be set to the value of the `origin` field when the webview was created. */
     origin?: string;
+  }
+  | {
+    $type: "loadUrl";
+    /** Optional headers to send with the request. */
+    headers?: Record<string, string>;
+    /** The id of the request. */
+    id: string;
+    /** URL to load in the webview. */
+    url: string;
   };
 export const WebViewRequest: z.ZodType<WebViewRequest> = z.discriminatedUnion(
   "$type",
@@ -224,6 +238,12 @@ export const WebViewRequest: z.ZodType<WebViewRequest> = z.discriminatedUnion(
       html: z.string(),
       id: z.string(),
       origin: z.string().optional(),
+    }),
+    z.object({
+      $type: z.literal("loadUrl"),
+      headers: z.record(z.string(), z.string()).optional(),
+      id: z.string(),
+      url: z.string(),
     }),
   ],
 );

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -45,6 +45,8 @@ export type WebViewOptions =
     title: string;
     /** Sets whether the window should be transparent. */
     transparent?: boolean;
+    /** Sets the user agent to use when loading pages. */
+    userAgent?: string;
   }
   & (
     | {
@@ -79,6 +81,7 @@ export const WebViewOptions: z.ZodType<WebViewOptions> = z.intersection(
       .optional(),
     title: z.string(),
     transparent: z.boolean().optional(),
+    userAgent: z.string().optional(),
   }),
   z.union([
     z.object({


### PR DESCRIPTION
- Adds the ability to load a new URL in the webview via `webview.loadUrl`. 
- When creating a webview with a URL you can now specify headers
- When creating a webview you can now specify a user agent