### PR TITLE
Introduce mise; use it in ci

### DIFF
--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -54,23 +54,28 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary_name: deno-webview-linux
+            platform: linux
           - os: ubuntu-latest
             target: x86_64-pc-windows-msvc
             binary_name: deno-webview-windows
+            platform: windows
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: deno-webview-mac
+            platform: macos
           - os: macos-latest
             target: aarch64-apple-darwin
             binary_name: deno-webview-mac-arm64
-
+            platform: macos
     steps:
       - uses: actions/checkout@v4
 
       - uses: jdx/mise-action@v2
         env:
           RUSTUP_TARGET: ${{ matrix.target }}
+          MISE_ENV: ${{ matrix.platform }}
         with:
+          cache_key_prefix: mise-${{ matrix.target }}
           experimental: true
 
       - name: Install libwebkit2gtk (Linux)
@@ -78,25 +83,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev
-
-      - name: Get cargo-xwin version
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        id: cargo-xwin-version
-        run: |
-          VERSION=$(cargo search cargo-xwin --limit 1 | awk -F '"' '{print $2}')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Cache cargo-xwin
-        uses: actions/cache@v4
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        id: cache-cargo-xwin
-        with:
-          path: ~/.cargo/bin/cargo-xwin
-          key: ${{ runner.os }}-cargo-xwin-${{ steps.cargo-xwin-version.outputs.version }}-${{ hashFiles('rust-toolchain.toml') }}
-
-      - name: Install cargo-xwin (for Windows build)
-        if: matrix.target == 'x86_64-pc-windows-msvc' && steps.cache-cargo-xwin.outputs.cache-hit != 'true'
-        run: cargo install cargo-xwin
 
       - name: Set build flags
         id: build_flags
@@ -144,11 +130,13 @@ jobs:
 
       - name: Build (Windows)
         if: matrix.target == 'x86_64-pc-windows-msvc'
+        env:
+          MISE_ENV: windows
         run: |
-          cargo xwin build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }} -F transparent
+          mise x -- cargo xwin build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }} -F transparent
           mv target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/deno-webview.exe ${{ matrix.binary_name }}.exe
 
-          cargo xwin build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }} -F transparent -F devtools
+          mise x -- cargo xwin build ${{ steps.build_flags.outputs.flags }} --target ${{ matrix.target }} -F transparent -F devtools
           mv target/${{ matrix.target }}/${{ steps.build_flags.outputs.build_type }}/deno-webview.exe ${{ matrix.binary_name }}-devtools.exe
 
       - name: Upload artifact

--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -24,9 +24,10 @@ jobs:
             .gitignore
           key: ${{ runner.os }}-rust-test-${{ hashFiles('.github/workflows/rust-binary.yml', 'Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
 
-      - name: Install Rust
+      - uses: jdx/mise-action@v2
         if: steps.rust-changed.outputs.cache-hit != 'true'
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
+        with:
+          experimental: true
 
       - name: Run cargo test
         if: steps.rust-changed.outputs.cache-hit != 'true'
@@ -66,10 +67,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
+      - uses: jdx/mise-action@v2
+        env:
+          RUSTUP_TARGET: ${{ matrix.target }}
         with:
-          target: ${{ matrix.target }}
+          experimental: true
 
       - name: Install libwebkit2gtk (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'

--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -78,6 +78,8 @@ jobs:
           cache_key_prefix: mise-${{ matrix.target }}
           experimental: true
 
+      - run: mise x -- rustup target add ${{ matrix.target }}
+
       - name: Install libwebkit2gtk (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,10 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Deno
-        uses: denoland/setup-deno@v1
+      - uses: jdx/mise-action@v2
         with:
-          deno-version: v1.x
+          experimental: true
 
       - name: Lint
         run: deno lint
@@ -21,10 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Deno
-        uses: denoland/setup-deno@v1
+      - uses: jdx/mise-action@v2
         with:
-          deno-version: v1.x
+          experimental: true
 
       - name: Passes publish checks
         run: deno publish --dry-run
@@ -34,10 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Deno
-        uses: denoland/setup-deno@v1
+      - uses: jdx/mise-action@v2
         with:
-          deno-version: v1.x
+          experimental: true
 
       - name: Run deno codegen
         run: deno task gen:deno

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+deno = "2.1.4"
+rust = { version = "1.78.0", postinstall = "rustup component add rustfmt clippy" }

--- a/mise.windows.toml
+++ b/mise.windows.toml
@@ -1,0 +1,2 @@
+[tools]
+"cargo:cargo-xwin" = "0.18.3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.78.0"
-components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR adds [mise](https://mise.jdx.dev/) to manage versions of deno / rust / etc. I've been moving all of my projects over to this. 

It somewhat simplifies dependency installation _except_ when it comes to rust targets. I had to add a manual rustup target step for the binary build. 