### PR TITLE
Show why generation verification failed. 

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -47,5 +47,6 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             echo "Files have changed after running tests:"
             git status --porcelain
+            git diff
             exit 1
           fi


### PR DESCRIPTION
The verify action continues to fail for reasons I don't quite understand yet. I added `git diff` to the failure step to ensure I can at least see what was generated when it changes. 