### PR TITLE
Improve schema generation; Add tasks to mise; Update CI

### DIFF
--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -40,12 +40,6 @@ jobs:
 
       - run: mise x -- rustup target add ${{ matrix.target }}
 
-      - name: Install libwebkit2gtk (Linux)
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev
-
       - name: Set build flags
         id: build_flags
         run: |

--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -4,47 +4,7 @@ on:
   push:
 
 jobs:
-  test:
-    name: Test
-    runs-on: macos-latest
-    permissions:
-      actions: write
-    outputs:
-      changed: ${{ steps.rust-changed.outputs.cache-hit }}
-    steps:
-      - uses: actions/checkout@v4
-
-      # This is a hack, it's just used to exit early if nothing has changed
-      - name: Check for changes to Rust files
-        uses: actions/cache@v4
-        id: rust-changed
-        with:
-          lookup-only: true
-          path: |
-            .gitignore
-          key: ${{ runner.os }}-rust-test-${{ hashFiles('.github/workflows/rust-binary.yml', 'Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '**/*.rs') }}
-
-      - uses: jdx/mise-action@v2
-        if: steps.rust-changed.outputs.cache-hit != 'true'
-        with:
-          experimental: true
-
-      - name: Run cargo test
-        if: steps.rust-changed.outputs.cache-hit != 'true'
-        run: cargo test
-
-      - name: Check for changed files
-        if: steps.rust-changed.outputs.cache-hit != 'true'
-        run: |
-          if [[ -n $(git status --porcelain) ]]; then
-            echo "Files have changed after running tests:"
-            git status --porcelain
-            exit 1
-          fi
-
   build:
-    needs: test
-    if: needs.test.outputs.changed != 'true'
     name: Build on ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -35,7 +35,7 @@ jobs:
           RUSTUP_TARGET: ${{ matrix.target }}
           MISE_ENV: ${{ matrix.platform }}
         with:
-          cache_key_prefix: mise-${{ matrix.target }}
+          cache_key_prefix: mise-${{ hashFiles('mise.toml') }}-${{ matrix.target }}
           experimental: true
 
       - run: mise x -- rustup target add ${{ matrix.target }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ jobs:
           experimental: true
 
       - name: Lint
-        run: deno lint
+        run: mise lint
 
   publishable:
     runs-on: ubuntu-latest
@@ -36,8 +36,8 @@ jobs:
         with:
           experimental: true
 
-      - name: Run deno codegen
-        run: deno task gen:deno
+      - name: Run codegen
+        run: mise run gen
 
       - name: Check for changed files
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,6 +10,7 @@ jobs:
 
       - uses: jdx/mise-action@v2
         with:
+          cache_key_prefix: mise-{{hashFiles('mise.toml')}}
           experimental: true
 
       - name: Lint
@@ -34,6 +35,7 @@ jobs:
 
       - uses: jdx/mise-action@v2
         with:
+          cache_key_prefix: mise-{{hashFiles('mise.toml')}}
           experimental: true
 
       - name: Run codegen

--- a/deno.json
+++ b/deno.json
@@ -3,10 +3,6 @@
   "exports": "./src/lib.ts",
   "version": "0.0.17",
   "tasks": {
-    "dev": "deno run --watch main.ts",
-    "gen": "deno task gen:rust && deno task gen:deno",
-    "gen:rust": "cargo build && cargo test",
-    "gen:deno": "deno run -A scripts/generate-schema.ts && deno run -A scripts/sync-versions.ts",
     "build": "deno task gen && cargo build -F transparent -F devtools",
     "example": "deno run -A scripts/example.ts"
   },

--- a/mise.toml
+++ b/mise.toml
@@ -33,3 +33,15 @@ depends = ["gen:deno", "build:rust"]
 
 [tasks.build]
 depends = ["build:*"]
+
+## Lint
+
+[tasks."lint:rust"]
+run = ["cargo fmt --check", "cargo clippy"]
+
+[tasks."lint:deno"]
+dir = "src"
+run = "deno lint"
+
+[tasks."lint"]
+depends = ["lint:*"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,17 @@
 [tools]
 deno = "2.1.4"
-rust = { version = "1.78.0", postinstall = "rustup component add rustfmt clippy" }
+rust = { version = "1.78.0", postinstall = "mise run postinstall:rust" }
 
 [settings]
 experimental = true
+
+[tasks."postinstall:rust"]
+run = ["rustup component add rustfmt clippy", """
+    {% if os() == "linux" and env.CI %}
+    sudo apt-get update
+    sudo apt-get install -y libwebkit2gtk-4.1-dev 
+    {% endif %}
+  """]
 
 [tasks.sync-versions]
 run = "deno run -A scripts/sync-versions.ts"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,35 @@
 [tools]
 deno = "2.1.4"
 rust = { version = "1.78.0", postinstall = "rustup component add rustfmt clippy" }
+
+[settings]
+experimental = true
+
+[tasks.sync-versions]
+run = "deno run -A scripts/sync-versions.ts"
+
+## Gen
+
+[tasks."gen:rust"]
+run = "cargo run --bin generate_schemas"
+
+[tasks."gen:deno"]
+run = "deno run -A scripts/generate-schema.ts"
+depends = ["gen:rust"]
+sources = ["schemas/*", "scripts/generate-schema.ts"]
+outputs = ["src/clients/deno/schemas.ts"]
+
+[tasks.gen]
+depends = ["gen:*"]
+
+## Build
+
+[tasks."build:rust"]
+run = "cargo build -F transparent -F devtools"
+depends = ["gen:rust"]
+
+[tasks."build:deno"]
+depends = ["gen:deno", "build:rust"]
+
+[tasks.build]
+depends = ["build:*"]

--- a/src/bin/generate_schemas.rs
+++ b/src/bin/generate_schemas.rs
@@ -1,0 +1,20 @@
+use deno_webview::{Message, Request, Response, WebViewOptions};
+use schemars::schema_for;
+use std::fs::File;
+use std::io::Write;
+
+fn main() {
+    let schemas = [
+        ("WebViewOptions", schema_for!(WebViewOptions)),
+        ("WebViewMessage", schema_for!(Message)),
+        ("WebViewRequest", schema_for!(Request)),
+        ("WebViewResponse", schema_for!(Response)),
+    ];
+
+    for (name, schema) in schemas {
+        let schema_json = serde_json::to_string_pretty(&schema).unwrap();
+        let mut file = File::create(format!("schemas/{}.json", name)).unwrap();
+        file.write_all(schema_json.as_bytes()).unwrap();
+        println!("Generated schema for {}", name);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+mod main;
+
+pub use main::{Message, Notification, Request, Response, WebViewOptions};

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ enum WindowSize {
 /// Options for creating a webview.
 #[derive(JsonSchema, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-struct WebViewOptions {
+pub struct WebViewOptions {
     /// Sets the title of the window.
     title: String,
     #[serde(flatten)]
@@ -134,7 +134,7 @@ fn default_origin() -> String {
 #[derive(JsonSchema, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type", content = "data")]
-enum Message {
+pub enum Message {
     Notification(Notification),
     Response(Response),
 }
@@ -143,7 +143,7 @@ enum Message {
 #[derive(JsonSchema, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type")]
-enum Notification {
+pub enum Notification {
     Started {
         /// The version of the webview binary
         version: String,
@@ -159,7 +159,7 @@ enum Notification {
 #[derive(JsonSchema, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type")]
-enum Request {
+pub enum Request {
     GetVersion {
         /// The id of the request.
         id: String,
@@ -254,7 +254,7 @@ enum Request {
 #[derive(JsonSchema, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type")]
-enum Response {
+pub enum Response {
     Ack { id: String },
     Result { id: String, result: ResultType },
     Err { id: String, message: String },
@@ -591,28 +591,4 @@ fn main() -> wry::Result<()> {
             _ => (),
         }
     });
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use schemars::schema_for;
-    use std::fs::File;
-    use std::io::Write;
-
-    #[test]
-    fn generate_json_schemas() {
-        let schemas = [
-            ("WebViewOptions", schema_for!(WebViewOptions)),
-            ("WebViewMessage", schema_for!(Message)),
-            ("WebViewRequest", schema_for!(Request)),
-            ("WebViewResponse", schema_for!(Response)),
-        ];
-
-        for (name, schema) in schemas {
-            let schema_json = serde_json::to_string_pretty(&schema).unwrap();
-            let mut file = File::create(format!("schemas/{}.json", name)).unwrap();
-            file.write_all(schema_json.as_bytes()).unwrap();
-        }
-    }
 }


### PR DESCRIPTION
Few different things here, all more or less oriented around the same goals. 

The first, and biggest task: Stop using `cargo test` to do codegen. This was a pattern I'd seen used at Oxide (which usually only wrote if a certain env var was set), but I decided to just pull it out into a separate bin. 

The other big piece of work is consolidating tasks in mise instead of having them spread over cargo/deno tasks. This'll be important as more clients are added. 

Last thing is just updating CI to use mise where appropriate. 