### PR TITLE
Vendor json schema types

### DIFF
--- a/json-schema.d.ts
+++ b/json-schema.d.ts
@@ -1,0 +1,133 @@
+export type JSONSchemaTypeName =
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "object"
+  | "array"
+  | "null";
+
+/**
+ * Primitive type
+ * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.1.1
+ */
+export type JSONSchemaType =
+  | string //
+  | number
+  | boolean
+  | { [key: string]: JSONSchemaType }
+  | JSONSchemaType[]
+  | null;
+
+/**
+ * JSON Schema v7
+ * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01
+ */
+export interface JSONSchema {
+  $id?: string;
+  $ref?: string;
+  $schema?: string;
+  $comment?: string;
+
+  /**
+   * @see https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-8.2.4
+   * @see https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#appendix-A
+   */
+  $defs?: {
+    [key: string]: JSONSchema;
+  };
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.1
+   */
+  type?: JSONSchemaTypeName | JSONSchemaTypeName[];
+  enum?: JSONSchemaType[];
+  const?: JSONSchemaType;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.2
+   */
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: number;
+  minimum?: number;
+  exclusiveMinimum?: number;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.3
+   */
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.4
+   */
+  items?: JSONSchema | JSONSchema[];
+  additionalItems?: JSONSchema;
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  contains?: JSONSchema;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.5
+   */
+  maxProperties?: number;
+  minProperties?: number;
+  required?: string[];
+  properties?: {
+    [key: string]: JSONSchema;
+  };
+  patternProperties?: {
+    [key: string]: JSONSchema;
+  };
+  additionalProperties?: JSONSchema;
+  dependencies?: {
+    [key: string]: JSONSchema | string[];
+  };
+  propertyNames?: JSONSchema | undefined;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.6
+   */
+  if?: JSONSchema;
+  then?: JSONSchema;
+  else?: JSONSchema;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.7
+   */
+  allOf?: JSONSchema[];
+  anyOf?: JSONSchema[];
+  oneOf?: JSONSchema[];
+  not?: JSONSchema;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7
+   */
+  format?: string;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-8
+   */
+  contentMediaType?: string;
+  contentEncoding?: string;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9
+   */
+  definitions?: {
+    [key: string]: JSONSchema;
+  };
+
+  /**
+   * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-10
+   */
+  title?: string | undefined;
+  description?: string | undefined;
+  default?: JSONSchemaType | undefined;
+  readOnly?: boolean | undefined;
+  writeOnly?: boolean | undefined;
+  examples?: JSONSchemaType | undefined;
+}

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -1,11 +1,7 @@
 import { walk } from "https://deno.land/std@0.190.0/fs/walk.ts";
 import { basename } from "https://deno.land/std@0.190.0/path/mod.ts";
 import { match, P } from "npm:ts-pattern";
-import type {
-  JSONSchema7 as JSONSchema,
-  JSONSchema7Definition as JSONSchemaDefinition,
-  JSONSchema7TypeName,
-} from "npm:@types/json-schema";
+import type { JSONSchema, JSONSchemaTypeName } from "../json-schema.d.ts";
 
 const schemasDir = new URL("../schemas", import.meta.url).pathname;
 const outputFile = new URL("../src/schemas.ts", import.meta.url).pathname;
@@ -42,14 +38,14 @@ type NodeIR =
   | { type: "float"; minimum?: number; maximum?: number }
   | { type: "unknown" };
 
-const isDescriminatedUnion = (def: JSONSchemaDefinition[] | undefined) => {
+const isDescriminatedUnion = (def: JSONSchema[] | undefined) => {
   return def && typeof def[0] === "object" &&
     (def[0]?.required?.[0] + "").startsWith("$");
 };
 
 const isOptionalType =
   (typeOf: string) =>
-  (type: JSONSchema7TypeName | JSONSchema7TypeName[] | undefined) => {
+  (type: JSONSchemaTypeName | JSONSchemaTypeName[] | undefined) => {
     if (type && Array.isArray(type) && type[0] === typeOf) {
       return true;
     }


### PR DESCRIPTION
The json schema types from `npm:@types/json-schema` have a bit of an unfortunate type signature. There's a `JsonSchema7Definition` that's typed as `JsonSchema7 | boolean` and returned by a lot of properties in `JsonSchema7`. My generation _never_ uses that type but it forced a lot of type narrowing _and_ that types package has a lot of historical json schema versions in it too. Just decided to vendor a narrowed down version of the types. 