### PR TITLE
Add mise extension with symlink config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 _test*
 .DS_Store
+.vscode/mise-tools

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"hverlin.mise-vscode",
+		"denoland.vscode-deno"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,10 @@
   },
   "[json]": {
     "editor.defaultFormatter": "denoland.vscode-deno"
-  }
+  },
+  "debug.javascript.defaultRuntimeExecutable": {
+    "pwa-node": "${workspaceFolder}/.vscode/mise-tools/node"
+  },
+  "deno.path": "${workspaceFolder}/.vscode/mise-tools/deno",
+  "mise.configureExtensionsUseSymLinks": true
 }


### PR DESCRIPTION
This PR depends on https://github.com/denoland/vscode_deno/pull/1245 to work correctly. I have a folk locally that makes it work for me so I'll merge it early, but others will need to alter the config. 

Adds the mise extension as a recommendation and enables the symlink configuration to point binaries at local symlinks. 