### PR TITLE
Generate separate schema files; add printer for codegen debugging

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -84,5 +84,5 @@ depends = ["lint:*"]
 description = "Run a deno example"
 depends = ["build:deno"]
 env = { WEBVIEW_BIN = "../../../target/debug/deno-webview" }
-run = "deno run -E -R --allow-run examples/{{arg(name=\"example\")}}.ts"
+run = "deno run -E -R -N --allow-run examples/{{arg(name=\"example\")}}.ts"
 dir = "src/clients/deno"


### PR DESCRIPTION
Running the tldraw example fails due to lack of network access. Seems fine to generally allow net for examples. 