### PR TITLE
Add command to print simplified visualization of schemas

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -34,6 +34,15 @@ depends = ["gen:rust"]
 sources = ["schemas/*", "scripts/generate-schema.ts"]
 outputs = ["src/clients/deno/schemas.ts"]
 
+## Debug
+
+[tasks."print-schema"]
+description = "Prints a simplified version of the schema"
+usage = '''
+arg "[schema]" help="The schema to print; prints all if not provided"
+'''
+run = "deno run -A scripts/generate-schema/debug.ts {{arg(name=\"schema\")}}"
+
 ## Publishing
 
 [tasks."verify-publish:deno"]

--- a/scripts/generate-schema/debug.ts
+++ b/scripts/generate-schema/debug.ts
@@ -1,0 +1,34 @@
+import { parseSchema } from "./parser.ts";
+import { printDocIR } from "./printer.ts";
+
+const schemaFiles = [
+  "WebViewOptions.json",
+  "WebViewRequest.json",
+  "WebViewResponse.json",
+  "WebViewMessage.json",
+];
+
+async function main() {
+  const targetSchema = Deno.args[0];
+  const filesToProcess = targetSchema
+    ? [targetSchema.endsWith(".json") ? targetSchema : `${targetSchema}.json`]
+    : schemaFiles;
+
+  for (const schemaFile of filesToProcess) {
+    if (!schemaFiles.includes(schemaFile)) {
+      console.error(`Invalid schema file: ${schemaFile}`);
+      console.error(`Available schemas: ${schemaFiles.join(", ")}`);
+      Deno.exit(1);
+    }
+
+    console.log(`Schema: ${schemaFile}`);
+
+    const schema = JSON.parse(await Deno.readTextFile(`schemas/${schemaFile}`));
+    const doc = parseSchema(schema);
+    console.log(printDocIR(doc));
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/scripts/generate-schema/printer.ts
+++ b/scripts/generate-schema/printer.ts
@@ -1,0 +1,169 @@
+import { match } from "npm:ts-pattern";
+import { Doc, Node } from "./parser.ts";
+import { blue, bold, dimmed, green, mix, yellow } from "jsr:@coven/terminal";
+
+const comment = mix(yellow, dimmed);
+const string = green;
+const type = blue;
+const kind = bold;
+
+function printNodeIR(
+  node: Node,
+  prefix: string = "",
+  isLast: boolean = true,
+): string {
+  const marker = isLast ? "└── " : "├── ";
+  const childPrefix = prefix + (isLast ? "    " : "│   ");
+  let result = "";
+
+  // Print description if present
+  if ("description" in node) {
+    result += prefix + marker + `[${node.description}]\n`;
+    result += prefix + marker;
+  } else {
+    result += prefix + marker;
+  }
+
+  return result + match(node)
+    .with({ type: "reference" }, ({ name }) => name)
+    .with({ type: "descriminated-union" }, ({ descriminator, members }) => {
+      let output = kind`discriminated-union` + ` (by ${descriminator})\n`;
+      Object.entries(members).forEach(([name, properties], index) => {
+        output += printNodeIR(
+          { type: "object", name, properties },
+          childPrefix,
+          index === Object.values(members).length - 1,
+        );
+      });
+      return output;
+    })
+    .with({ type: "intersection" }, ({ members }) => {
+      let output = kind`intersection\n`;
+      members.forEach((member, index) => {
+        output += printNodeIR(
+          member,
+          childPrefix,
+          index === members.length - 1,
+        );
+      });
+      return output;
+    })
+    .with({ type: "union" }, ({ members }) => {
+      let output = kind`union\n`;
+      members.forEach((member, index) => {
+        output += printNodeIR(
+          member,
+          childPrefix,
+          index === members.length - 1,
+        );
+      });
+      return output;
+    })
+    .with({ type: "object" }, ({ name, properties }) => {
+      let output = kind`${name ?? "object"}\n`;
+      properties.forEach(({ key, required, value, description }, index) => {
+        const propDesc = `${key}${required ? "" : "?"}: `;
+
+        if (description) {
+          output += childPrefix + "│   " +
+            comment`${description}\n`;
+          output += childPrefix +
+            (index === properties.length - 1 ? "└── " : "├── ");
+        } else {
+          output += childPrefix +
+            (index === properties.length - 1 ? "└── " : "├── ");
+        }
+
+        const valueStr = match(value)
+          .with(
+            { type: "boolean" },
+            ({ optional }) => type`boolean${optional ? "?" : ""}`,
+          )
+          .with(
+            { type: "string" },
+            ({ optional }) => type`string${optional ? "?" : ""}`,
+          )
+          .with({ type: "literal" }, ({ value }) => string`"${value}"`)
+          .with(
+            { type: "int" },
+            ({ minimum, maximum }) =>
+              type`int${minimum !== undefined ? ` min(${minimum})` : ""}${
+                maximum !== undefined ? ` max(${maximum})` : ""
+              }`,
+          )
+          .with(
+            { type: "float" },
+            ({ minimum, maximum }) =>
+              type`float${minimum !== undefined ? ` min(${minimum})` : ""}${
+                maximum !== undefined ? ` max(${maximum})` : ""
+              }`,
+          )
+          .with(
+            { type: "record" },
+            ({ valueType }) => type`record<string, ${valueType}>`,
+          )
+          .with({ type: "unknown" }, () => "unknown")
+          .with({ type: "reference" }, ({ name }) => name)
+          .otherwise(() => {
+            output += propDesc + "\n";
+            return printNodeIR(
+              value,
+              childPrefix + (index === properties.length - 1 ? "    " : "│   "),
+              true,
+            );
+          });
+
+        if (
+          value.type === "union" || value.type === "intersection" ||
+          value.type === "descriminated-union" || value.type === "object"
+        ) {
+          output += valueStr;
+        } else {
+          output += propDesc + valueStr + "\n";
+        }
+      });
+      return output;
+    })
+    .with({ type: "enum" }, ({ members }) => {
+      return kind`enum` + `[${members.join(",")}]\n`;
+    })
+    .with(
+      { type: "record" },
+      ({ valueType }) => `record<string, ${valueType}>\n`,
+    )
+    .with(
+      { type: "boolean" },
+      ({ optional }) => `boolean${optional ? "?" : ""}\n`,
+    )
+    .with(
+      { type: "string" },
+      ({ optional }) => `string${optional ? "?" : ""}\n`,
+    )
+    .with({ type: "literal" }, ({ value }) => `"${value}"\n`)
+    .with(
+      { type: "int" },
+      ({ minimum, maximum }) =>
+        `int${minimum !== undefined ? ` min(${minimum})` : ""}${
+          maximum !== undefined ? ` max(${maximum})` : ""
+        }\n`,
+    )
+    .with(
+      { type: "float" },
+      ({ minimum, maximum }) =>
+        `float${minimum !== undefined ? ` min(${minimum})` : ""}${
+          maximum !== undefined ? ` max(${maximum})` : ""
+        }\n`,
+    )
+    .with({ type: "unknown" }, () => "unknown\n")
+    .exhaustive();
+}
+
+export function printDocIR(doc: Doc): string {
+  let result = `${doc.title}\n`;
+  if (doc.description) {
+    result += "│   description: " +
+      comment`${doc.description.split("\n")[0]}\n`;
+  }
+  result += printNodeIR(doc.root, "", true);
+  return result;
+}


### PR DESCRIPTION
Pulled out of #78 

This PR adds a printer and debug command to the generation setup. You can use `mise run print-schema` to invoke it or `mise run print-schema WebViewOptions` to print a single schema. 

The output looks like this

```
Response
│   description: Responses from the webview to the client.
└── discriminated-union (by $type)
    ├── ack
    │   └── id: string
    ├── result
    │   ├── id: string
    │   └── result: ResultType
    └── err
        ├── id: string
        └── message: string
```