### PR TITLE
Fix deno linting in multi-client setup

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -91,8 +91,8 @@ run = ["cargo fmt --check", "cargo clippy"]
 
 [tasks."lint:deno"]
 description = "Run deno lint"
-dir = "src"
-run = "deno lint"
+dir = "src/clients/deno"
+run = ["deno lint", "deno check ."]
 
 [tasks."lint"]
 description = "Run all linting tasks"


### PR DESCRIPTION
When I merged #100 I missed updating the working directory of the lint command. While I was updating this, I added `deno check .` which should check for type errors in the deno client .