### PR TITLE
Use actson for incremental json parsing; test processing code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "actson"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e30cd26b5ca4cb0f31cc21260062cb6fb1becc5e79b6aa491daecee90e0e3fa3"
+dependencies = [
+ "btoi",
+ "num-traits",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +82,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1078,6 +1098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,11 +2056,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -2047,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2279,6 +2308,7 @@ dependencies = [
 name = "webview"
 version = "0.1.14"
 dependencies = [
+ "actson",
  "parking_lot",
  "schemars",
  "serde",
@@ -2607,7 +2637,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1038,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1108,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-conv"
@@ -1359,6 +1387,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pango"
@@ -1707,6 +1741,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1935,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2086,6 +2173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2274,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,6 +2383,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"
@@ -2314,6 +2478,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tao",
+ "tracing",
+ "tracing-subscriber",
  "wry",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tao = "0.31.0"
 wry = "0.48.0"
 schemars = "0.8.21"
 parking_lot = "0.12"
+actson = "2.0.0"
 
 [features]
 transparent = ["wry/transparent"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ wry = "0.48.0"
 schemars = "0.8.21"
 parking_lot = "0.12"
 actson = "2.0.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 transparent = ["wry/transparent"]

--- a/src/bin/webview.rs
+++ b/src/bin/webview.rs
@@ -1,7 +1,18 @@
 use std::env;
+use tracing::error;
 use webview::{run, WebViewOptions};
+
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let webview_options: WebViewOptions = serde_json::from_str(&args[1]).unwrap();
-    run(webview_options).unwrap();
+    let webview_options: WebViewOptions = match serde_json::from_str(&args[1]) {
+        Ok(options) => options,
+        Err(e) => {
+            error!("Failed to parse webview options: {:?}", e);
+            std::process::exit(1);
+        }
+    };
+    if let Err(e) = run(webview_options) {
+        error!("Webview error: {:?}", e);
+        std::process::exit(1);
+    }
 }

--- a/src/clients/deno/main.ts
+++ b/src/clients/deno/main.ts
@@ -217,7 +217,7 @@ export class WebView implements Disposable {
       });
       this.#stdin.write(
         new TextEncoder().encode(
-          JSON.stringify({ ...request, id }).replace("\0", "") + "\0",
+          JSON.stringify({ ...request, id }),
         ),
       );
     });
@@ -231,14 +231,15 @@ export class WebView implements Disposable {
       }
       this.#buffer += new TextDecoder().decode(value);
 
-      const NulCharIndex = this.#buffer.indexOf("\0");
-      if (NulCharIndex === -1) {
+      const newlineIndex = this.#buffer.indexOf("\n");
+      if (newlineIndex === -1) {
         continue;
       }
+      console.error("buffer", this.#buffer);
       const result = WebViewMessage.safeParse(
-        JSON.parse(this.#buffer.slice(0, NulCharIndex)),
+        JSON.parse(this.#buffer.slice(0, newlineIndex)),
       );
-      this.#buffer = this.#buffer.slice(NulCharIndex + 1);
+      this.#buffer = this.#buffer.slice(newlineIndex + 1);
       if (result.success) {
         return result.data;
       } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
+use actson::options::JsonParserOptionsBuilder;
 use parking_lot::Mutex;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::env;
-use std::io::{self, BufRead, Write};
+use std::io::{BufReader, Read, Write};
 use std::str::FromStr;
-use std::sync::mpsc;
+use std::sync::mpsc::{self, Sender};
 use std::sync::Arc;
 
 use schemars::JsonSchema;
@@ -21,10 +22,13 @@ use wry::http::header::{HeaderName, HeaderValue};
 use wry::http::Response as HttpResponse;
 use wry::WebViewBuilder;
 
+use actson::feeder::BufReaderJsonFeeder;
+use actson::{JsonEvent, JsonParser};
+
 /// The version of the webview binary.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(JsonSchema, Deserialize, Debug)]
+#[derive(JsonSchema, Deserialize, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SimpleSize {
     width: f64,
@@ -132,7 +136,7 @@ fn default_origin() -> String {
 // --- RPC Definitions ---
 
 /// Complete definition of all outbound messages from the webview to the client.
-#[derive(JsonSchema, Serialize, Debug)]
+#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type", content = "data")]
 pub enum Message {
@@ -141,7 +145,7 @@ pub enum Message {
 }
 
 /// Messages that are sent unbidden from the webview to the client.
-#[derive(JsonSchema, Serialize, Debug)]
+#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type")]
 pub enum Notification {
@@ -157,7 +161,7 @@ pub enum Notification {
 }
 
 /// Explicit requests from the client to the webview.
-#[derive(JsonSchema, Deserialize, Debug)]
+#[derive(JsonSchema, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type")]
 pub enum Request {
@@ -252,7 +256,7 @@ pub enum Request {
 }
 
 /// Responses from the webview to the client.
-#[derive(JsonSchema, Serialize, Debug)]
+#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type")]
 pub enum Response {
@@ -262,7 +266,7 @@ pub enum Response {
 }
 
 /// Types that can be returned from webview results.
-#[derive(JsonSchema, Serialize, Debug)]
+#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type", content = "value")]
 #[allow(dead_code)]
@@ -292,6 +296,108 @@ impl From<bool> for ResultType {
     }
 }
 
+/// Incrementally parses JSON input from a reader and sends the parsed requests to a sender.
+///
+/// This is used in the main program to read JSON input from stdin and send it to the webview
+/// event loop.
+fn process_input<R: Read + std::marker::Send + 'static>(
+    reader: BufReader<R>,
+    sender: Sender<Request>,
+) {
+    std::thread::spawn(move || {
+        let feeder = BufReaderJsonFeeder::new(reader);
+        let mut parser = JsonParser::new_with_options(
+            feeder,
+            JsonParserOptionsBuilder::default()
+                .with_streaming(true)
+                .build(),
+        );
+
+        let mut json_string = String::new();
+        let mut depth = 0;
+
+        while let Some(event) = parser.next_event().unwrap() {
+            match event {
+                JsonEvent::NeedMoreInput => parser.feeder.fill_buf().unwrap(),
+                JsonEvent::StartObject => {
+                    depth += 1;
+                    json_string.push('{');
+                }
+                JsonEvent::EndObject => {
+                    depth -= 1;
+                    json_string.push('}');
+
+                    // If we're back at depth 0, we have a complete JSON object
+                    if depth == 0 {
+                        match serde_json::from_str::<Request>(&json_string) {
+                            Ok(request) => sender.send(request).unwrap(),
+                            Err(e) => eprintln!("Failed to deserialize request: {:?}", e),
+                        }
+                        json_string.clear();
+                    }
+                }
+                JsonEvent::StartArray => {
+                    depth += 1;
+                    json_string.push('[');
+                }
+                JsonEvent::EndArray => {
+                    depth -= 1;
+                    json_string.push(']');
+                }
+                JsonEvent::FieldName => {
+                    if json_string.ends_with('{') {
+                        json_string.push('"');
+                    } else {
+                        json_string.push_str(",\"");
+                    }
+                    json_string.push_str(parser.current_str().unwrap());
+                    json_string.push_str("\":");
+                }
+                JsonEvent::ValueString => {
+                    json_string.push('"');
+                    json_string.push_str(parser.current_str().unwrap());
+                    json_string.push('"');
+                }
+                JsonEvent::ValueInt => {
+                    json_string.push_str(&parser.current_int::<i64>().unwrap().to_string());
+                }
+                JsonEvent::ValueFloat => {
+                    json_string.push_str(&parser.current_float().unwrap().to_string());
+                }
+                JsonEvent::ValueTrue => json_string.push_str("true"),
+                JsonEvent::ValueFalse => json_string.push_str("false"),
+                JsonEvent::ValueNull => json_string.push_str("null"),
+            }
+        }
+    });
+}
+
+/// Incrementally writes messages to a writer.
+///
+/// This is used in the main program to write messages to stdout.
+fn process_output<W: Write + std::marker::Send + 'static>(
+    writer: W,
+    receiver: mpsc::Receiver<Message>,
+) {
+    std::thread::spawn(move || {
+        let mut writer = std::io::BufWriter::new(writer);
+
+        while let Ok(event) = receiver.recv() {
+            match serde_json::to_string(&event) {
+                Ok(json) => {
+                    let mut buffer = json.into_bytes();
+                    buffer.push(b'\n');
+                    writer.write_all(&buffer).unwrap();
+                    writer.flush().unwrap();
+                }
+                Err(err) => {
+                    eprintln!("Failed to serialize event: {:?} {:?}", event, err);
+                }
+            }
+        }
+    });
+}
+
 pub fn run(webview_options: WebViewOptions) -> wry::Result<()> {
     // These two mutexes are used to store the html and origin if the webview is created with html.
     // The html mutex is needed to provide a value to the custom protocol and origin is needed
@@ -299,8 +405,8 @@ pub fn run(webview_options: WebViewOptions) -> wry::Result<()> {
     let html_mutex = Arc::new(Mutex::new("".to_string()));
     let origin_mutex = Arc::new(Mutex::new(default_origin().to_string()));
 
-    let (tx, to_deno) = mpsc::channel::<Message>();
-    let (from_deno, rx) = mpsc::channel::<Request>();
+    let (tx, from_webview) = mpsc::channel::<Message>();
+    let (to_eventloop, rx) = mpsc::channel::<Request>();
 
     let event_loop = EventLoop::new();
     let mut window_builder = WindowBuilder::new()
@@ -341,7 +447,7 @@ pub fn run(webview_options: WebViewOptions) -> wry::Result<()> {
             webview_builder
         }
         Some(WebViewContent::Html { html, origin }) => {
-            *origin_mutex.lock() = origin.clone();
+            origin_mutex.lock().clone_from(&origin);
             *html_mutex.lock() = html;
             WebViewBuilder::new().with_url(&format!("load-html://{}", origin))
         }
@@ -390,45 +496,10 @@ pub fn run(webview_options: WebViewOptions) -> wry::Result<()> {
     };
 
     // Handle messages from the webview to the client.
-    std::thread::spawn(move || {
-        let stdout = std::io::stdout();
-        let mut stdout_lock = stdout.lock();
-
-        while let Ok(event) = to_deno.recv() {
-            match serde_json::to_string(&event) {
-                Ok(json) => {
-                    let mut buffer = json.replace("\0", "").into_bytes();
-                    buffer.push(0); // Add null byte
-                    stdout_lock.write_all(&buffer).unwrap();
-                    stdout_lock.flush().unwrap();
-                }
-                Err(err) => {
-                    eprintln!("Failed to serialize event: {:?} {:?}", event, err);
-                }
-            }
-        }
-    });
+    process_output(std::io::stdout(), from_webview);
 
     // Handle messages from the client to the webview.
-    std::thread::spawn(move || {
-        let stdin = io::stdin();
-        let mut stdin = stdin.lock();
-        let mut buf = Vec::<u8>::new();
-
-        while stdin.read_until(b'\0', &mut buf).is_ok() {
-            if buf.is_empty() {
-                break; // EOF reached
-            }
-            // Remove null byte
-            buf.pop();
-
-            match serde_json::from_slice::<Request>(&buf) {
-                Ok(event) => from_deno.send(event).unwrap(),
-                Err(e) => eprintln!("Failed to deserialize: {:?}", e),
-            }
-            buf.clear()
-        }
-    });
+    process_input(BufReader::new(std::io::stdin()), to_eventloop);
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
@@ -547,7 +618,7 @@ pub fn run(webview_options: WebViewOptions) -> wry::Result<()> {
                             *html_mutex.lock() = html;
                             let origin = match origin {
                                 Some(origin) => {
-                                    *origin_mutex.lock() = origin.clone();
+                                    origin_mutex.lock().clone_from(&origin);
                                     origin
                                 }
                                 None => origin_mutex.lock().clone(),
@@ -588,4 +659,312 @@ pub fn run(webview_options: WebViewOptions) -> wry::Result<()> {
             _ => (),
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_process_input_simple() {
+        // Create a GetVersion request
+        let request = Request::GetVersion {
+            id: "test-123".to_string(),
+        };
+
+        // Serialize to JSON
+        let json = serde_json::to_vec(&request).unwrap();
+        let cursor = Cursor::new(json);
+        let reader = BufReader::new(cursor);
+        let (sender, receiver) = mpsc::channel();
+
+        // Capture stderr output
+        let stderr = std::io::stderr();
+        let _handle = stderr.lock();
+
+        process_input(reader, sender);
+
+        // Give the thread a moment to process
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Try to receive the message
+        match receiver.try_recv() {
+            Ok(received) => {
+                assert!(matches!(
+                    received,
+                    Request::GetVersion { id } if id == "test-123"
+                ));
+            }
+            Err(e) => panic!("Failed to receive message: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_process_input_complex() {
+        // Create a SetSize request with nested SimpleSize
+        let request = Request::SetSize {
+            id: "size-test".to_string(),
+            size: SimpleSize {
+                width: 800.0,
+                height: 600.0,
+            },
+        };
+
+        // Serialize to JSON
+        let json = serde_json::to_vec(&request).unwrap();
+        let cursor = Cursor::new(json);
+        let reader = BufReader::new(cursor);
+        let (sender, receiver) = mpsc::channel();
+
+        process_input(reader, sender);
+
+        // Give the thread a moment to process
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Try to receive the message
+        match receiver.try_recv() {
+            Ok(received) => match received {
+                Request::SetSize { id, size } => {
+                    assert_eq!(id, "size-test");
+                    assert_eq!(size.width, 800.0);
+                    assert_eq!(size.height, 600.0);
+                }
+                other => panic!("Unexpected request type: {:?}", other),
+            },
+            Err(e) => panic!("Failed to receive message: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_process_output() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_clone = output.clone();
+        let (sender, receiver) = mpsc::channel();
+
+        // Start processing output
+        process_output(WriteGuard(output_clone), receiver);
+
+        // Create and send a test message
+        let message = Message::Response(Response::Ack {
+            id: "test-123".to_string(),
+        });
+        sender.send(message).unwrap();
+
+        // Give the thread a moment to process
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Check the output
+        let output_str = String::from_utf8(output.lock().clone()).unwrap();
+        let expected = serde_json::json!({
+            "$type": "response",
+            "data": {
+                "$type": "ack",
+                "id": "test-123"
+            }
+        });
+        let expected_str = expected.to_string() + "\n";
+        assert_eq!(output_str, expected_str);
+    }
+
+    // Helper struct to implement Write for our Arc<Mutex<Vec<u8>>>
+    struct WriteGuard(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for WriteGuard {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.0.lock().flush()
+        }
+    }
+
+    #[test]
+    fn test_process_input_multiple() {
+        // Create multiple requests
+        let requests = vec![
+            Request::GetVersion {
+                id: "version-1".to_string(),
+            },
+            Request::SetSize {
+                id: "size-1".to_string(),
+                size: SimpleSize {
+                    width: 1024.0,
+                    height: 768.0,
+                },
+            },
+            Request::LoadUrl {
+                id: "url-1".to_string(),
+                url: "https://example.com".to_string(),
+                headers: Some(HashMap::from([
+                    ("User-Agent".to_string(), "test-agent".to_string()),
+                    ("Accept".to_string(), "text/html".to_string()),
+                ])),
+            },
+        ];
+
+        // Serialize each request and concatenate
+        let mut json = Vec::new();
+        for request in &requests {
+            json.extend(serde_json::to_vec(request).unwrap());
+        }
+
+        let cursor = Cursor::new(json);
+        let reader = BufReader::new(cursor);
+        let (sender, receiver) = mpsc::channel();
+
+        process_input(reader, sender);
+
+        // Give the thread a moment to process
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Try to receive all messages in order
+        for expected in requests {
+            match receiver.try_recv() {
+                Ok(received) => match (received, expected) {
+                    (Request::GetVersion { id: rid }, Request::GetVersion { id: eid }) => {
+                        assert_eq!(rid, eid);
+                    }
+                    (
+                        Request::SetSize {
+                            id: rid,
+                            size: rsize,
+                        },
+                        Request::SetSize {
+                            id: eid,
+                            size: esize,
+                        },
+                    ) => {
+                        assert_eq!(rid, eid);
+                        assert_eq!(rsize.width, esize.width);
+                        assert_eq!(rsize.height, esize.height);
+                    }
+                    (
+                        Request::LoadUrl {
+                            id: rid,
+                            url: rurl,
+                            headers: rheaders,
+                        },
+                        Request::LoadUrl {
+                            id: eid,
+                            url: eurl,
+                            headers: eheaders,
+                        },
+                    ) => {
+                        assert_eq!(rid, eid);
+                        assert_eq!(rurl, eurl);
+                        assert_eq!(rheaders, eheaders);
+                    }
+                    _ => panic!("Unexpected request type mismatch"),
+                },
+                Err(e) => panic!("Failed to receive message: {:?}", e),
+            }
+        }
+
+        // Verify no more messages
+        assert!(
+            receiver.try_recv().is_err(),
+            "Should not have any more messages"
+        );
+    }
+
+    #[test]
+    fn test_process_output_multiple() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_clone = output.clone();
+        let (sender, receiver) = mpsc::channel();
+
+        // Start processing output
+        process_output(WriteGuard(output_clone), receiver);
+
+        // Create and send multiple test messages
+        let messages = vec![
+            Message::Response(Response::Ack {
+                id: "test-1".to_string(),
+            }),
+            Message::Notification(Notification::Started {
+                version: "1.0.0".to_string(),
+            }),
+            Message::Response(Response::Result {
+                id: "test-2".to_string(),
+                result: ResultType::Size {
+                    width: 800.0,
+                    height: 600.0,
+                    scale_factor: 1.0,
+                },
+            }),
+        ];
+
+        // Send all messages
+        for message in messages.clone() {
+            sender.send(message).unwrap();
+        }
+
+        // Give the thread a moment to process
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Get the output and split by newlines
+        let output_str = String::from_utf8(output.lock().clone()).unwrap();
+        let received_messages: Vec<Message> = output_str
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+
+        // Verify we got all messages in order
+        assert_eq!(received_messages.len(), messages.len());
+        for (received, expected) in received_messages.iter().zip(messages.iter()) {
+            match (received, expected) {
+                (
+                    Message::Response(Response::Ack { id: rid }),
+                    Message::Response(Response::Ack { id: eid }),
+                ) => {
+                    assert_eq!(rid, eid);
+                }
+                (
+                    Message::Notification(Notification::Started { version: rver }),
+                    Message::Notification(Notification::Started { version: ever }),
+                ) => {
+                    assert_eq!(rver, ever);
+                }
+                (
+                    Message::Response(Response::Result {
+                        id: rid,
+                        result: rres,
+                    }),
+                    Message::Response(Response::Result {
+                        id: eid,
+                        result: eres,
+                    }),
+                ) => {
+                    assert_eq!(rid, eid);
+                    match (rres, eres) {
+                        (
+                            ResultType::Size {
+                                width: rw,
+                                height: rh,
+                                scale_factor: rs,
+                            },
+                            ResultType::Size {
+                                width: ew,
+                                height: eh,
+                                scale_factor: es,
+                            },
+                        ) => {
+                            assert_eq!(rw, ew);
+                            assert_eq!(rh, eh);
+                            assert_eq!(rs, es);
+                        }
+                        _ => panic!("Unexpected result type"),
+                    }
+                }
+                _ => panic!("Message type mismatch"),
+            }
+        }
+
+        // Verify each line is valid JSON
+        for line in output_str.lines() {
+            assert!(serde_json::from_str::<Message>(line).is_ok());
+        }
+    }
 }


### PR DESCRIPTION
Closes #107. 

I've implemented a new json parsing scheme for the webview. The webview binary itself uses `actson` to [incrementally parse incoming json](https://docs.rs/actson/2.0.0/actson/#parsing-in-streaming-mode-multiple-top-level-json-values). That means all a client has to do to send a message to the webview is just write the json blob to its stdin. No delimiters are required for comms going to the webview. 

When the webview responds with JSON (via stdout) it newline delineates the messages. This is the easy cross language mechanism of output parsing. 

I also added the `tracing` create so I can get some debug logs to figure out what's going on in the webview. 