### PR TITLE
Update logging; add pattern matching to deno client

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -103,6 +103,6 @@ depends = ["lint:*"]
 [tasks."example:deno"]
 description = "Run a deno example"
 depends = ["build:deno"]
-env = { WEBVIEW_BIN = "../../../target/debug/webview" }
+env = { LOG_LEVEL = "debug", WEBVIEW_BIN = "../../../target/debug/webview" }
 run = "deno run -E -R -N --allow-run examples/{{arg(name=\"example\")}}.ts"
 dir = "src/clients/deno"

--- a/src/clients/deno/deno.json
+++ b/src/clients/deno/deno.json
@@ -7,6 +7,8 @@
     "include": ["README.md", "LICENSE", "*.ts", "schemas/*.ts"]
   },
   "imports": {
+    "ts-pattern": "jsr:@gabriel/ts-pattern@^5.6.2",
+    "tracing": "jsr:@bcheidemann/tracing@^0.6.3",
     "jsr:@std/fs": "jsr:@std/fs@^1.0.3",
     "jsr:@std/path": "jsr:@std/path@^1.0.6",
     "jsr:@std/ulid": "jsr:@std/ulid@^1.0.0",

--- a/src/clients/deno/deno.lock
+++ b/src/clients/deno/deno.lock
@@ -1,19 +1,57 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@bcheidemann/parse-params@0.5": "0.5.0",
+    "jsr:@bcheidemann/tracing@~0.6.3": "0.6.3",
+    "jsr:@gabriel/ts-pattern@^5.6.2": "5.6.2",
+    "jsr:@std/assert@0.226": "0.226.0",
+    "jsr:@std/assert@0.226.0": "0.226.0",
+    "jsr:@std/fmt@~0.225.4": "0.225.6",
     "jsr:@std/fs@^1.0.3": "1.0.6",
+    "jsr:@std/internal@1": "1.0.5",
     "jsr:@std/path@^1.0.6": "1.0.8",
     "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/ulid@1": "1.0.0",
+    "npm:acorn@8.12.0": "8.12.0",
     "npm:type-fest@^4.26.1": "4.30.2",
     "npm:zod@^3.23.8": "3.23.8"
   },
   "jsr": {
+    "@bcheidemann/parse-params@0.5.0": {
+      "integrity": "a13a95163fad0cbd34890cb5d43df3466cc96e97e76674052592a90bbf56bbab",
+      "dependencies": [
+        "jsr:@std/assert@0.226.0",
+        "npm:acorn"
+      ]
+    },
+    "@bcheidemann/tracing@0.6.3": {
+      "integrity": "d6f38e77ef142a88b9eaeff3a2df54a8a24b2226fff747119ddc40726a05abeb",
+      "dependencies": [
+        "jsr:@bcheidemann/parse-params",
+        "jsr:@std/assert@0.226",
+        "jsr:@std/fmt"
+      ]
+    },
+    "@gabriel/ts-pattern@5.6.2": {
+      "integrity": "49a1069523e2ba53d024d6b17a30029f8ffc80b24fec86d724d986a9774a7197"
+    },
+    "@std/assert@0.226.0": {
+      "integrity": "0dfb5f7c7723c18cec118e080fec76ce15b4c31154b15ad2bd74822603ef75b3",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/fmt@0.225.6": {
+      "integrity": "aba6aea27f66813cecfd9484e074a9e9845782ab0685c030e453a8a70b37afc8"
+    },
     "@std/fs@1.0.6": {
       "integrity": "42b56e1e41b75583a21d5a37f6a6a27de9f510bcd36c0c85791d685ca0b85fa2",
       "dependencies": [
         "jsr:@std/path@^1.0.8"
       ]
+    },
+    "@std/internal@1.0.5": {
+      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
     },
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
@@ -23,6 +61,9 @@
     }
   },
   "npm": {
+    "acorn@8.12.0": {
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw=="
+    },
     "type-fest@4.30.2": {
       "integrity": "sha512-UJShLPYi1aWqCdq9HycOL/gwsuqda1OISdBO3t8RlXQC4QvtuIz4b5FCfe2dQIWEpmlRExKmcTBfP1r9bhY7ig=="
     },
@@ -35,6 +76,8 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@bcheidemann/tracing@~0.6.3",
+      "jsr:@gabriel/ts-pattern@^5.6.2",
       "jsr:@std/fs@^1.0.3",
       "jsr:@std/path@^1.0.6",
       "jsr:@std/ulid@1",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ fn process_output<W: Write + std::marker::Send + 'static>(
 pub fn run(webview_options: WebViewOptions) -> wry::Result<()> {
     // Initialize tracing subscriber
     tracing_subscriber::fmt()
-        .with_env_filter(env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string()))
+        .with_env_filter(env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_string()))
         .with_writer(std::io::stderr)
         .init();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tao::dpi::{LogicalSize, Size};
 use tao::window::Fullscreen;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use tao::{
     event::{Event, StartCause, WindowEvent},


### PR DESCRIPTION
At first all I wanted to do was add a `tracing` like library to get consistent logging in the deno client. I ended up also integrating `ts-pattern` to clean up some of the long conditional chains / switch statements. 

Also, when you run `mise run example:deno <example>` now you get logging enabled out of the box. 