### PR TITLE
Start tracing in binary

### DIFF
--- a/src/bin/webview.rs
+++ b/src/bin/webview.rs
@@ -3,7 +3,14 @@ use tracing::error;
 use webview::{run, WebViewOptions};
 
 fn main() {
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_string()))
+        .with_writer(std::io::stderr)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
     let args: Vec<String> = env::args().collect();
+
     let webview_options: WebViewOptions = match serde_json::from_str(&args[1]) {
         Ok(options) => options,
         Err(e) => {
@@ -11,6 +18,7 @@ fn main() {
             std::process::exit(1);
         }
     };
+
     if let Err(e) = run(webview_options) {
         error!("Webview error: {:?}", e);
         std::process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,12 +404,6 @@ fn process_output<W: Write + std::marker::Send + 'static>(
 }
 
 pub fn run(webview_options: WebViewOptions) -> wry::Result<()> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt()
-        .with_env_filter(env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_string()))
-        .with_writer(std::io::stderr)
-        .init();
-
     info!("Starting webview with options: {:?}", webview_options);
 
     // These two mutexes are used to store the html and origin if the webview is created with html.
@@ -462,7 +456,7 @@ pub fn run(webview_options: WebViewOptions) -> wry::Result<()> {
         Some(WebViewContent::Html { html, origin }) => {
             origin_mutex.lock().clone_from(&origin);
             *html_mutex.lock() = html;
-            WebViewBuilder::new().with_url(&format!("load-html://{}", origin))
+            WebViewBuilder::new().with_url(format!("load-html://{}", origin))
         }
         None => WebViewBuilder::new(),
     }


### PR DESCRIPTION
Ran into a really unfortunate issue when trying to debug the python client where the errors in the binary weren't being printed out because tracing hadn't yet been enabled. This moves the tracing setup code from `lib` to the binary. I assume this would make sense if someone wanted to consume the lib separately anyway, they may want to do their own thing with the tracing subscriber. 