### PR TITLE
Add trace level to deno client

### DIFF
--- a/src/clients/deno/main.ts
+++ b/src/clients/deno/main.ts
@@ -39,6 +39,7 @@ if (
     "granted"
 ) {
   const level = match(Deno.env.get("LOG_LEVEL"))
+    .with("trace", () => Level.TRACE)
     .with("debug", () => Level.DEBUG)
     .with("info", () => Level.INFO)
     .with("warn", () => Level.WARN)


### PR DESCRIPTION
When I added tracing to the deno client I realized I missed the actual `trace` level, ha. This adds that. 