### PR TITLE
Add github token to stop hitting limits when mise installing

### DIFF
--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           RUSTUP_TARGET: ${{ matrix.target }}
           MISE_ENV: ${{ matrix.platform }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           cache_key_prefix: mise-${{ hashFiles('mise.toml') }}-${{ matrix.target }}
           experimental: true


### PR DESCRIPTION
Hopefully will fix [this failure](https://github.com/zephraph/webview/actions/runs/13192542767/job/36828031782?pr=78#step:3:77).

Adds the built in `GITHUB_TOKEN` to prevent `mise install` from hitting unauthed github limits. 