### PR TITLE
Use shared vscode extensions plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ _test*
 .DS_Store
 __pycache__
 node_modules
-.vscode/mise-tools
+
+.vscode/*
+!.vscode/*.shared.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,8 @@
 	"recommendations": [
 		"hverlin.mise-vscode",
 		"denoland.vscode-deno",
-		"charliermarsh.ruff"
+		"charliermarsh.ruff",
+		"Swellaby.workspace-config-plus"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/.vscode/settings.shared.json
+++ b/.vscode/settings.shared.json
@@ -14,4 +14,5 @@
   "python.analysis.extraPaths": [
     "${workspaceFolder}/src/clients/python/.venv/lib/python3.*/site-packages"
   ],
+  "mise.configureExtensionsAutomatically": true
 }


### PR DESCRIPTION
The [mise-vscode](https://github.com/hverlin/mise-vscode) has an option `configureExtensionsAutomatically` which will automatically setup the paths to binaries for runtimes like deno, node, python, etc for anything configured in mise and used by vscode. This ends up writing absolute paths to the `settings.json` which makes it hard to share settings with other folks. This is more a failing of vscode than of mise-vscode. To attempt to help with this issue, `mise-vscode` will do automatic symlinking in `.vscode/mise-tools` and configure local paths. As I [unfortunately found out](https://github.com/hverlin/mise-vscode/discussions/96), vscode also doesn't path references they provide for extensions to consume so support of these features is dependent on an extension maintainer's willingness to add it. The deno team [refused to add this support](https://github.com/denoland/vscode_deno/pull/1245) which ultimately makes it feel like a non-starter to me. 

Thankfully @swellaby implemented [vscode-workspace-config-plus](https://github.com/swellaby/vscode-workspace-config-plus) which gives some rudimentary ability to share config. It doesn't look like the extension is actively maintained, but its functional enough to achieve what I need from it. 