### PR TITLE
Only build binary on impacting changes; various small changes

### DIFF
--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -2,6 +2,10 @@ name: Rust Binary
 
 on:
   push:
+    paths:
+      - 'src/**/*rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 
 .vscode/*
 !.vscode/*.shared.json
+!.vscode/extensions.json

--- a/mise.toml
+++ b/mise.toml
@@ -36,12 +36,14 @@ description = "Generate the deno client"
 run = "deno run -A scripts/generate-schema/index.ts --language typescript"
 depends = ["gen:rust"]
 sources = ["schemas/*", "scripts/generate-schema.ts"]
-outputs = ["src/clients/deno/schemas.ts"]
+outputs = ["src/clients/deno/schemas/*.ts"]
 
 [tasks."gen:python"]
 description = "Generate the python client"
 run = "deno run -A scripts/generate-schema/index.ts --language python"
 depends = ["gen:rust"]
+sources = ["schemas/*", "scripts/generate-schema.ts"]
+outputs = ["src/clients/python/src/webview_python/schemas/*.py"]
 
 ## Debug
 

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ uv = "0.6.0"
 
 [settings]
 experimental = true
+pin = true
 
 [tasks."ci:install-deps"]
 hide = true


### PR DESCRIPTION
This is mainly to reduce my actions usage. There could be a consequence here on releases, so I'll have to keep an eye out for that. 