### PR TITLE
simplify client ids

### DIFF
--- a/schemas/WebViewMessage.json
+++ b/schemas/WebViewMessage.json
@@ -115,7 +115,8 @@
               ]
             },
             "id": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             }
           }
         },
@@ -134,7 +135,8 @@
               ]
             },
             "id": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "result": {
               "$ref": "#/definitions/ResultType"
@@ -156,7 +158,8 @@
               ]
             },
             "id": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "message": {
               "type": "string"

--- a/schemas/WebViewRequest.json
+++ b/schemas/WebViewRequest.json
@@ -18,7 +18,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -38,7 +39,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "js": {
           "description": "The javascript to evaluate.",
@@ -62,7 +64,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "title": {
           "description": "The title to set.",
@@ -85,7 +88,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -105,7 +109,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "visible": {
           "description": "Whether the window should be visible or hidden.",
@@ -128,7 +133,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -147,7 +153,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -166,7 +173,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "include_decorations": {
           "description": "Whether to include the title bar and borders in the size measurement.",
@@ -194,7 +202,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "size": {
           "description": "The size to set.",
@@ -228,7 +237,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -247,7 +257,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "maximized": {
           "description": "Whether to maximize the window. If left unspecified, the window will be maximized if it is not already maximized or restored if it was previously maximized.",
@@ -273,7 +284,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "minimized": {
           "description": "Whether to minimize the window. If left unspecified, the window will be minimized if it is not already minimized or restored if it was previously minimized.",
@@ -304,7 +316,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "origin": {
           "description": "What to set as the origin of the webview when loading html. If not specified, the origin will be set to the value of the `origin` field when the webview was created.",
@@ -341,7 +354,8 @@
         },
         "id": {
           "description": "The id of the request.",
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "url": {
           "description": "URL to load in the webview.",

--- a/schemas/WebViewResponse.json
+++ b/schemas/WebViewResponse.json
@@ -17,7 +17,8 @@
           ]
         },
         "id": {
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -36,7 +37,8 @@
           ]
         },
         "id": {
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "result": {
           "$ref": "#/definitions/ResultType"
@@ -58,7 +60,8 @@
           ]
         },
         "id": {
-          "type": "string"
+          "type": "integer",
+          "format": "int64"
         },
         "message": {
           "type": "string"

--- a/src/clients/deno/deno.json
+++ b/src/clients/deno/deno.json
@@ -11,7 +11,6 @@
     "tracing": "jsr:@bcheidemann/tracing@^0.6.3",
     "jsr:@std/fs": "jsr:@std/fs@^1.0.3",
     "jsr:@std/path": "jsr:@std/path@^1.0.6",
-    "jsr:@std/ulid": "jsr:@std/ulid@^1.0.0",
     "npm:zod": "npm:zod@^3.23.8",
     "npm:type-fest": "npm:type-fest@^4.26.1"
   }

--- a/src/clients/deno/deno.lock
+++ b/src/clients/deno/deno.lock
@@ -11,7 +11,6 @@
     "jsr:@std/internal@1": "1.0.5",
     "jsr:@std/path@^1.0.6": "1.0.8",
     "jsr:@std/path@^1.0.8": "1.0.8",
-    "jsr:@std/ulid@1": "1.0.0",
     "npm:acorn@8.12.0": "8.12.0",
     "npm:type-fest@^4.26.1": "4.30.2",
     "npm:zod@^3.23.8": "3.23.8"
@@ -55,9 +54,6 @@
     },
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
-    },
-    "@std/ulid@1.0.0": {
-      "integrity": "d41c3d27a907714413649fee864b7cde8d42ee68437d22b79d5de4f81d808780"
     }
   },
   "npm": {
@@ -80,7 +76,6 @@
       "jsr:@gabriel/ts-pattern@^5.6.2",
       "jsr:@std/fs@^1.0.3",
       "jsr:@std/path@^1.0.6",
-      "jsr:@std/ulid@1",
       "npm:type-fest@^4.26.1",
       "npm:zod@^3.23.8"
     ]

--- a/src/clients/deno/schemas.ts
+++ b/src/clients/deno/schemas.ts
@@ -60,19 +60,19 @@ export type Response =
   | {
     $type: "ack";
 
-    id: string;
+    id: number;
   }
   | {
     $type: "result";
 
-    id: string;
+    id: number;
 
     result: ResultType;
   }
   | {
     $type: "err";
 
-    id: string;
+    id: number;
 
     message: string;
   };
@@ -115,9 +115,17 @@ export const ResultType: z.ZodType<ResultType> = z.discriminatedUnion("$type", [
 ]);
 
 export const Response: z.ZodType<Response> = z.discriminatedUnion("$type", [
-  z.object({ $type: z.literal("ack"), id: z.string() }),
-  z.object({ $type: z.literal("result"), id: z.string(), result: ResultType }),
-  z.object({ $type: z.literal("err"), id: z.string(), message: z.string() }),
+  z.object({ $type: z.literal("ack"), id: z.number().int() }),
+  z.object({
+    $type: z.literal("result"),
+    id: z.number().int(),
+    result: ResultType,
+  }),
+  z.object({
+    $type: z.literal("err"),
+    id: z.number().int(),
+    message: z.string(),
+  }),
 ]);
 
 export const Message: z.ZodType<Message> = z.discriminatedUnion("$type", [
@@ -244,55 +252,55 @@ export type Request =
   | {
     $type: "getVersion";
     /** The id of the request. */
-    id: string;
+    id: number;
   }
   | {
     $type: "eval";
     /** The id of the request. */
-    id: string;
+    id: number;
     /** The javascript to evaluate. */
     js: string;
   }
   | {
     $type: "setTitle";
     /** The id of the request. */
-    id: string;
+    id: number;
     /** The title to set. */
     title: string;
   }
   | {
     $type: "getTitle";
     /** The id of the request. */
-    id: string;
+    id: number;
   }
   | {
     $type: "setVisibility";
     /** The id of the request. */
-    id: string;
+    id: number;
     /** Whether the window should be visible or hidden. */
     visible: boolean;
   }
   | {
     $type: "isVisible";
     /** The id of the request. */
-    id: string;
+    id: number;
   }
   | {
     $type: "openDevTools";
     /** The id of the request. */
-    id: string;
+    id: number;
   }
   | {
     $type: "getSize";
     /** The id of the request. */
-    id: string;
+    id: number;
     /** Whether to include the title bar and borders in the size measurement. */
     include_decorations?: boolean;
   }
   | {
     $type: "setSize";
     /** The id of the request. */
-    id: string;
+    id: number;
     /** The size to set. */
     size: Size;
   }
@@ -301,19 +309,19 @@ export type Request =
     /** Whether to enter fullscreen mode. If left unspecified, the window will enter fullscreen mode if it is not already in fullscreen mode or exit fullscreen mode if it is currently in fullscreen mode. */
     fullscreen?: boolean;
     /** The id of the request. */
-    id: string;
+    id: number;
   }
   | {
     $type: "maximize";
     /** The id of the request. */
-    id: string;
+    id: number;
     /** Whether to maximize the window. If left unspecified, the window will be maximized if it is not already maximized or restored if it was previously maximized. */
     maximized?: boolean;
   }
   | {
     $type: "minimize";
     /** The id of the request. */
-    id: string;
+    id: number;
     /** Whether to minimize the window. If left unspecified, the window will be minimized if it is not already minimized or restored if it was previously minimized. */
     minimized?: boolean;
   }
@@ -322,7 +330,7 @@ export type Request =
     /** HTML to set as the content of the webview. */
     html: string;
     /** The id of the request. */
-    id: string;
+    id: number;
     /** What to set as the origin of the webview when loading html. If not specified, the origin will be set to the value of the `origin` field when the webview was created. */
     origin?: string;
   }
@@ -331,54 +339,58 @@ export type Request =
     /** Optional headers to send with the request. */
     headers?: Record<string, string>;
     /** The id of the request. */
-    id: string;
+    id: number;
     /** URL to load in the webview. */
     url: string;
   };
 
 export const Request: z.ZodType<Request> = z.discriminatedUnion("$type", [
-  z.object({ $type: z.literal("getVersion"), id: z.string() }),
-  z.object({ $type: z.literal("eval"), id: z.string(), js: z.string() }),
-  z.object({ $type: z.literal("setTitle"), id: z.string(), title: z.string() }),
-  z.object({ $type: z.literal("getTitle"), id: z.string() }),
+  z.object({ $type: z.literal("getVersion"), id: z.number().int() }),
+  z.object({ $type: z.literal("eval"), id: z.number().int(), js: z.string() }),
+  z.object({
+    $type: z.literal("setTitle"),
+    id: z.number().int(),
+    title: z.string(),
+  }),
+  z.object({ $type: z.literal("getTitle"), id: z.number().int() }),
   z.object({
     $type: z.literal("setVisibility"),
-    id: z.string(),
+    id: z.number().int(),
     visible: z.boolean(),
   }),
-  z.object({ $type: z.literal("isVisible"), id: z.string() }),
-  z.object({ $type: z.literal("openDevTools"), id: z.string() }),
+  z.object({ $type: z.literal("isVisible"), id: z.number().int() }),
+  z.object({ $type: z.literal("openDevTools"), id: z.number().int() }),
   z.object({
     $type: z.literal("getSize"),
-    id: z.string(),
+    id: z.number().int(),
     include_decorations: z.boolean().optional(),
   }),
-  z.object({ $type: z.literal("setSize"), id: z.string(), size: Size }),
+  z.object({ $type: z.literal("setSize"), id: z.number().int(), size: Size }),
   z.object({
     $type: z.literal("fullscreen"),
     fullscreen: z.boolean().optional(),
-    id: z.string(),
+    id: z.number().int(),
   }),
   z.object({
     $type: z.literal("maximize"),
-    id: z.string(),
+    id: z.number().int(),
     maximized: z.boolean().optional(),
   }),
   z.object({
     $type: z.literal("minimize"),
-    id: z.string(),
+    id: z.number().int(),
     minimized: z.boolean().optional(),
   }),
   z.object({
     $type: z.literal("loadHtml"),
     html: z.string(),
-    id: z.string(),
+    id: z.number().int(),
     origin: z.string().optional(),
   }),
   z.object({
     $type: z.literal("loadUrl"),
     headers: z.record(z.string(), z.string()).optional(),
-    id: z.string(),
+    id: z.number().int(),
     url: z.string(),
   }),
 ]);

--- a/src/clients/python/src/webview_python/__init__.py
+++ b/src/clients/python/src/webview_python/__init__.py
@@ -43,6 +43,7 @@ from .schemas import (
     LoadHtmlRequest,
     LoadUrlRequest,
     Size,
+    ContentHtml as WebViewContentHtml,
 )
 
 # Constants
@@ -143,8 +144,8 @@ class WebView:
         self.buffer = b""
 
     @property
-    def message_id(self) -> str:
-        current_id = f"client_{self.__message_id}"
+    def message_id(self) -> int:
+        current_id = self.__message_id
         self.__message_id += 1
         return current_id
 
@@ -254,7 +255,7 @@ class WebView:
                         if isinstance(msg, NotificationMessage):
                             return msg.data
                         elif isinstance(msg, ResponseMessage):
-                            self.internal_event.emit(msg.data.id, msg.data)
+                            self.internal_event.emit(str(msg.data.id), msg.data)
                     except msgspec.DecodeError as e:
                         print(f"Error parsing message: {message}", flush=True)
                         print(f"Parse error details: {str(e)}", flush=True)

--- a/src/clients/python/src/webview_python/schemas.py
+++ b/src/clients/python/src/webview_python/schemas.py
@@ -43,14 +43,14 @@ ResultType  = Union[StringResultType, BooleanResultType, FloatResultType, SizeRe
 Types that can be returned from webview results. 
 """ 
 class AckResponse(msgspec.Struct, tag_field="$type", tag="ack"): 
-    id: str
+    id: int
 
 class ResultResponse(msgspec.Struct, tag_field="$type", tag="result"): 
-    id: str
+    id: int
     result: ResultType
 
 class ErrResponse(msgspec.Struct, tag_field="$type", tag="err"): 
-    id: str
+    id: int
     message: str
 
 Response  = Union[AckResponse, ResultResponse, ErrResponse] 
@@ -140,65 +140,65 @@ Platform-specific: - Windows: Requires WebView2 Runtime version 101.0.1210.39 or
 
 
 class GetVersionRequest(msgspec.Struct, tag_field="$type", tag="getVersion"): 
-    id: str
+    id: int
     """The id of the request.""" 
 
 class EvalRequest(msgspec.Struct, tag_field="$type", tag="eval"): 
-    id: str
+    id: int
     """The id of the request.""" 
     js: str
     """The javascript to evaluate.""" 
 
 class SetTitleRequest(msgspec.Struct, tag_field="$type", tag="setTitle"): 
-    id: str
+    id: int
     """The id of the request.""" 
     title: str
     """The title to set.""" 
 
 class GetTitleRequest(msgspec.Struct, tag_field="$type", tag="getTitle"): 
-    id: str
+    id: int
     """The id of the request.""" 
 
 class SetVisibilityRequest(msgspec.Struct, tag_field="$type", tag="setVisibility"): 
-    id: str
+    id: int
     """The id of the request.""" 
     visible: bool
     """Whether the window should be visible or hidden.""" 
 
 class IsVisibleRequest(msgspec.Struct, tag_field="$type", tag="isVisible"): 
-    id: str
+    id: int
     """The id of the request.""" 
 
 class OpenDevToolsRequest(msgspec.Struct, tag_field="$type", tag="openDevTools"): 
-    id: str
+    id: int
     """The id of the request.""" 
 
 class GetSizeRequest(msgspec.Struct, tag_field="$type", tag="getSize"): 
-    id: str
+    id: int
     """The id of the request.""" 
     include_decorations: Union[bool, None] = None
     """Whether to include the title bar and borders in the size measurement.""" 
 
 class SetSizeRequest(msgspec.Struct, tag_field="$type", tag="setSize"): 
-    id: str
+    id: int
     """The id of the request.""" 
     size: Size
     """The size to set.""" 
 
 class FullscreenRequest(msgspec.Struct, tag_field="$type", tag="fullscreen"): 
-    id: str
+    id: int
     """The id of the request.""" 
     fullscreen: Union[bool, None] = None
     """Whether to enter fullscreen mode. If left unspecified, the window will enter fullscreen mode if it is not already in fullscreen mode or exit fullscreen mode if it is currently in fullscreen mode.""" 
 
 class MaximizeRequest(msgspec.Struct, tag_field="$type", tag="maximize"): 
-    id: str
+    id: int
     """The id of the request.""" 
     maximized: Union[bool, None] = None
     """Whether to maximize the window. If left unspecified, the window will be maximized if it is not already maximized or restored if it was previously maximized.""" 
 
 class MinimizeRequest(msgspec.Struct, tag_field="$type", tag="minimize"): 
-    id: str
+    id: int
     """The id of the request.""" 
     minimized: Union[bool, None] = None
     """Whether to minimize the window. If left unspecified, the window will be minimized if it is not already minimized or restored if it was previously minimized.""" 
@@ -206,13 +206,13 @@ class MinimizeRequest(msgspec.Struct, tag_field="$type", tag="minimize"):
 class LoadHtmlRequest(msgspec.Struct, tag_field="$type", tag="loadHtml"): 
     html: str
     """HTML to set as the content of the webview.""" 
-    id: str
+    id: int
     """The id of the request.""" 
     origin: Union[str, None] = None
     """What to set as the origin of the webview when loading html. If not specified, the origin will be set to the value of the `origin` field when the webview was created.""" 
 
 class LoadUrlRequest(msgspec.Struct, tag_field="$type", tag="loadUrl"): 
-    id: str
+    id: int
     """The id of the request.""" 
     url: str
     """URL to load in the webview.""" 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,54 +181,54 @@ pub enum Notification {
 pub enum Request {
     GetVersion {
         /// The id of the request.
-        id: String,
+        id: i64,
     },
     Eval {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// The javascript to evaluate.
         js: String,
     },
     SetTitle {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// The title to set.
         title: String,
     },
     GetTitle {
         /// The id of the request.
-        id: String,
+        id: i64,
     },
     SetVisibility {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// Whether the window should be visible or hidden.
         visible: bool,
     },
     IsVisible {
         /// The id of the request.
-        id: String,
+        id: i64,
     },
     OpenDevTools {
         /// The id of the request.
-        id: String,
+        id: i64,
     },
     GetSize {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// Whether to include the title bar and borders in the size measurement.
         #[serde(default)]
         include_decorations: Option<bool>,
     },
     SetSize {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// The size to set.
         size: Size,
     },
     Fullscreen {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// Whether to enter fullscreen mode.
         /// If left unspecified, the window will enter fullscreen mode if it is not already in fullscreen mode
         /// or exit fullscreen mode if it is currently in fullscreen mode.
@@ -236,7 +236,7 @@ pub enum Request {
     },
     Maximize {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// Whether to maximize the window.
         /// If left unspecified, the window will be maximized if it is not already maximized
         /// or restored if it was previously maximized.
@@ -244,7 +244,7 @@ pub enum Request {
     },
     Minimize {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// Whether to minimize the window.
         /// If left unspecified, the window will be minimized if it is not already minimized
         /// or restored if it was previously minimized.
@@ -252,7 +252,7 @@ pub enum Request {
     },
     LoadHtml {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// HTML to set as the content of the webview.
         html: String,
         /// What to set as the origin of the webview when loading html.
@@ -261,7 +261,7 @@ pub enum Request {
     },
     LoadUrl {
         /// The id of the request.
-        id: String,
+        id: i64,
         /// URL to load in the webview.
         url: String,
         /// Optional headers to send with the request.
@@ -274,9 +274,9 @@ pub enum Request {
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "$type")]
 pub enum Response {
-    Ack { id: String },
-    Result { id: String, result: ResultType },
-    Err { id: String, message: String },
+    Ack { id: i64 },
+    Result { id: i64, result: ResultType },
+    Err { id: i64, message: String },
 }
 
 /// Types that can be returned from webview results.
@@ -692,9 +692,7 @@ mod tests {
     #[test]
     fn test_process_input_simple() {
         // Create a GetVersion request
-        let request = Request::GetVersion {
-            id: "test-123".to_string(),
-        };
+        let request = Request::GetVersion { id: 0 };
 
         // Serialize to JSON
         let json = serde_json::to_vec(&request).unwrap();
@@ -716,7 +714,7 @@ mod tests {
             Ok(received) => {
                 assert!(matches!(
                     received,
-                    Request::GetVersion { id } if id == "test-123"
+                    Request::GetVersion { id } if id == 0
                 ));
             }
             Err(e) => panic!("Failed to receive message: {:?}", e),
@@ -727,7 +725,7 @@ mod tests {
     fn test_process_input_complex() {
         // Create a SetSize request with nested SimpleSize
         let request = Request::SetSize {
-            id: "size-test".to_string(),
+            id: 0,
             size: Size {
                 width: 800.0,
                 height: 600.0,
@@ -749,7 +747,7 @@ mod tests {
         match receiver.try_recv() {
             Ok(received) => match received {
                 Request::SetSize { id, size } => {
-                    assert_eq!(id, "size-test");
+                    assert_eq!(id, 0);
                     assert_eq!(size.width, 800.0);
                     assert_eq!(size.height, 600.0);
                 }
@@ -769,9 +767,7 @@ mod tests {
         process_output(WriteGuard(output_clone), receiver);
 
         // Create and send a test message
-        let message = Message::Response(Response::Ack {
-            id: "test-123".to_string(),
-        });
+        let message = Message::Response(Response::Ack { id: 0 });
         sender.send(message).unwrap();
 
         // Give the thread a moment to process
@@ -783,7 +779,7 @@ mod tests {
             "$type": "response",
             "data": {
                 "$type": "ack",
-                "id": "test-123"
+                "id": 0
             }
         });
         let expected_str = expected.to_string() + "\n";
@@ -807,18 +803,16 @@ mod tests {
     fn test_process_input_multiple() {
         // Create multiple requests
         let requests = vec![
-            Request::GetVersion {
-                id: "version-1".to_string(),
-            },
+            Request::GetVersion { id: 0 },
             Request::SetSize {
-                id: "size-1".to_string(),
+                id: 0,
                 size: Size {
                     width: 1024.0,
                     height: 768.0,
                 },
             },
             Request::LoadUrl {
-                id: "url-1".to_string(),
+                id: 0,
                 url: "https://example.com".to_string(),
                 headers: Some(HashMap::from([
                     ("User-Agent".to_string(), "test-agent".to_string()),
@@ -903,14 +897,12 @@ mod tests {
 
         // Create and send multiple test messages
         let messages = vec![
-            Message::Response(Response::Ack {
-                id: "test-1".to_string(),
-            }),
+            Message::Response(Response::Ack { id: 0 }),
             Message::Notification(Notification::Started {
                 version: "1.0.0".to_string(),
             }),
             Message::Response(Response::Result {
-                id: "test-2".to_string(),
+                id: 0,
                 result: ResultType::Size(SizeWithScale {
                     width: 800.0,
                     height: 600.0,


### PR DESCRIPTION
Instead of using string IDs, this updates request ids to be numbers. Clients can just send over incrementing integers. 

IDs are just used to match client requests with responses from the webview. Their contents isn't really that important. 