### PR TITLE
Prepare for python release

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,82 @@
+name: Publish Python Client
+on:
+  workflow_run:
+    workflows: ["Verify", "Release Rust Binary"]
+    types:
+      - completed
+    branches: [main]
+  pull_request:
+    paths:
+      - 'src/clients/python/**'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Only run if the workflow_run was successful (for the main branch case)
+    if: github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success'
+    
+    defaults:
+      run:
+        working-directory: src/clients/python
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+
+      - name: Install tools
+        run: mise install
+
+      - name: Get current version
+        id: current_version
+        run: echo "version=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Get published version
+        id: published_version
+        run: |
+          if ! version=$(curl -sf https://pypi.org/pypi/justbe-webview/json | jq -r '.info.version // "0.0.0"'); then
+            echo "Failed to fetch version from PyPI, using 0.0.0"
+            version="0.0.0"
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Build package
+        if: ${{ steps.current_version.outputs.version != steps.published_version.outputs.version || github.event_name == 'pull_request' }}
+        run: uv build
+
+      - name: Dry run publish to PyPI
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "Would publish version ${{ steps.current_version.outputs.version }} to PyPI"
+          echo "Current published version: ${{ steps.published_version.outputs.version }}"
+          echo "Package contents:"
+          ls -l dist/
+          echo "Archive contents:"
+          tar tzf dist/*.tar.gz | sort
+
+      - name: Publish to PyPI
+        if: ${{ steps.current_version.outputs.version != steps.published_version.outputs.version && github.event_name == 'workflow_run' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: src/clients/python/dist/
+          verbose: true
+
+      - name: Tag and push if versions differ
+        if: ${{ steps.current_version.outputs.version != steps.published_version.outputs.version && github.event_name == 'workflow_run' }}
+        run: |
+          # Ensure the tag doesn't already exist
+          if ! git rev-parse "python-v${{ steps.current_version.outputs.version }}" >/dev/null 2>&1; then
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git tag -a python-v${{ steps.current_version.outputs.version }} -m "Release ${{ steps.current_version.outputs.version }}"
+            git push origin python-v${{ steps.current_version.outputs.version }}
+          else
+            echo "Tag python-v${{ steps.current_version.outputs.version }} already exists, skipping tag creation"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/mise.toml
+++ b/mise.toml
@@ -44,7 +44,7 @@ description = "Generate the python client"
 run = "deno run -A scripts/generate-schema/index.ts --language python"
 depends = ["gen:rust"]
 sources = ["schemas/*", "scripts/generate-schema.ts"]
-outputs = ["src/clients/python/src/webview_python/schemas/*.py"]
+outputs = ["src/clients/python/src/justbe_webview/schemas/*.py"]
 
 ## Debug
 

--- a/scripts/generate-schema/gen-python.test.ts
+++ b/scripts/generate-schema/gen-python.test.ts
@@ -1,0 +1,70 @@
+import { assertEquals } from "jsr:@std/assert";
+import dedent from "npm:dedent";
+import { extractExportedNames } from "./gen-python.ts";
+
+Deno.test("extractExportedNames - extracts class names", () => {
+  const content = dedent`
+    class MyClass:
+        pass
+
+    class AnotherClass(msgspec.Struct):
+        field: str
+
+    def not_a_class():
+        pass
+  `;
+  assertEquals(extractExportedNames(content), ["AnotherClass", "MyClass"]);
+});
+
+Deno.test("extractExportedNames - extracts enum assignments", () => {
+  const content = dedent`
+    MyEnum = Union[ClassA, ClassB]
+    AnotherEnum = Union[ClassC, ClassD, ClassE]
+
+    not_an_enum = "something else"
+  `;
+  assertEquals(extractExportedNames(content), ["AnotherEnum", "MyEnum"]);
+});
+
+Deno.test("extractExportedNames - extracts both classes and enums", () => {
+  const content = dedent`
+    class MyClass:
+        pass
+
+    MyEnum = Union[ClassA, ClassB]
+
+    class AnotherClass:
+        field: str
+
+    AnotherEnum = Union[ClassC, ClassD]
+  `;
+  assertEquals(extractExportedNames(content), [
+    "AnotherClass",
+    "AnotherEnum",
+    "MyClass",
+    "MyEnum",
+  ]);
+});
+
+Deno.test("extractExportedNames - handles empty content", () => {
+  assertEquals(extractExportedNames(""), []);
+});
+
+Deno.test("extractExportedNames - ignores indented class definitions and enum assignments", () => {
+  const content = dedent`
+    def some_function():
+        class IndentedClass:
+            pass
+        
+        IndentedEnum = Union[ClassA, ClassB]
+
+    class TopLevelClass:
+        pass
+
+    TopLevelEnum = Union[ClassC, ClassD]
+  `;
+  assertEquals(extractExportedNames(content), [
+    "TopLevelClass",
+    "TopLevelEnum",
+  ]);
+});

--- a/scripts/generate-schema/index.ts
+++ b/scripts/generate-schema/index.ts
@@ -13,7 +13,7 @@ import { parseSchema } from "./parser.ts";
 const schemasDir = new URL("../../schemas", import.meta.url).pathname;
 const tsSchemaDir = new URL("../../src/clients/deno", import.meta.url).pathname;
 const pySchemaDir =
-  new URL("../../src/clients/python/src/webview_python", import.meta.url)
+  new URL("../../src/clients/python/src/justbe_webview", import.meta.url)
     .pathname;
 
 async function ensureDir(dir: string) {

--- a/scripts/generate-schema/index.ts
+++ b/scripts/generate-schema/index.ts
@@ -3,7 +3,11 @@ import { join } from "jsr:@std/path";
 import { parseArgs } from "jsr:@std/cli/parse-args";
 import type { JSONSchema } from "../../json-schema.d.ts";
 import { generateTypeScript } from "./gen-typescript.ts";
-import { generatePython } from "./gen-python.ts";
+import {
+  extractExportedNames,
+  generateAll,
+  generatePython,
+} from "./gen-python.ts";
 import { parseSchema } from "./parser.ts";
 
 const schemasDir = new URL("../../schemas", import.meta.url).pathname;
@@ -80,8 +84,18 @@ async function main() {
     const pyContent = schemas.map((doc) =>
       generatePython(doc, doc.title, relativePath)
     ).join("\n\n\n");
+
+    // Extract all exported names and generate __all__
+    const exportedNames = extractExportedNames(pyContent);
+    const allContent = generateAll(exportedNames);
+
+    // Insert __all__ after the header (which is in the first schema's output)
+    const headerEndIndex = pyContent.indexOf("\n\n") + 2;
+    const finalContent = pyContent.slice(0, headerEndIndex) + allContent +
+      pyContent.slice(headerEndIndex);
+
     const pyFilePath = join(pySchemaDir, "schemas.py");
-    await Deno.writeTextFile(pyFilePath, pyContent);
+    await Deno.writeTextFile(pyFilePath, finalContent);
     console.log(`Generated Python schemas: ${pyFilePath}`);
   }
 

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -28,7 +28,7 @@ await Deno.writeTextFile(denoPath, updatedDenoContent);
 console.log(`✓ Updated Deno BIN_VERSION to ${latestVersion}`);
 
 // ===== Update Python Client BIN_VERSION =====
-const pythonInitPath = "./src/clients/python/src/webview_python/__init__.py";
+const pythonInitPath = "./src/clients/python/src/justbe_webview/__init__.py";
 const pythonInitContent = await Deno.readTextFile(pythonInitPath);
 
 const updatedPythonInitContent = pythonInitContent.replace(

--- a/src/clients/python/examples/ipc.py
+++ b/src/clients/python/examples/ipc.py
@@ -1,23 +1,22 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "webview-python",
+#     "justbe-webview",
 # ]
 #
 # [tool.uv.sources]
-# webview-python = { path = "../" }
+# justbe-webview = { path = "../" }
 # ///
 import asyncio
 
-from webview_python import WebView, WebViewOptions, WebViewContentHtml
-from webview_python.schemas.WebViewMessage import IpcNotification
+from justbe_webview import WebView, Options, ContentHtml, IpcNotification
 
 
 async def main():
     print("Creating webview")
-    config = WebViewOptions(
+    config = Options(
         title="Simple",
-        load=WebViewContentHtml(
+        load=ContentHtml(
             html='<button onclick="window.ipc.postMessage(`button clicked ${Date.now()}`)">Click me</button>'
         ),
         ipc=True,

--- a/src/clients/python/examples/load_html.py
+++ b/src/clients/python/examples/load_html.py
@@ -1,29 +1,27 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "webview-python",
+#     "justbe-webview",
 # ]
 #
 # [tool.uv.sources]
-# webview-python = { path = "../" }
+# justbe-webview = { path = "../" }
 # ///
-import sys
 import asyncio
-from pathlib import Path
 
-from webview_python import (
+from justbe_webview import (
     WebView,
-    WebViewOptions,
-    WebViewContentHtml,
-    WebViewNotification,
+    Options,
+    ContentHtml,
+    Notification,
 )
 
 
 async def main():
     print("Creating webview")
-    config = WebViewOptions(
+    config = Options(
         title="Load Html Example",
-        load=WebViewContentHtml(
+        load=ContentHtml(
             html="<h1>Initial html</h1>",
             # Note: This origin is used with a custom protocol so it doesn't match
             # https://example.com. This doesn't need to be set, but can be useful if
@@ -36,7 +34,7 @@ async def main():
 
     async with WebView(config) as webview:
 
-        async def handle_start(event: WebViewNotification):
+        async def handle_start(event: Notification):
             await webview.open_devtools()
             await webview.load_html("<h1>Updated html!</h1>")
 
@@ -47,4 +45,3 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/src/clients/python/examples/load_url.py
+++ b/src/clients/python/examples/load_url.py
@@ -1,30 +1,27 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "webview-python",
+#     "justbe-webview",
 # ]
 #
 # [tool.uv.sources]
-# webview-python = { path = "../" }
+# justbe-webview = { path = "../" }
 # ///
-import sys
 import asyncio
-import time
-from pathlib import Path
 
-from webview_python import (
+from justbe_webview import (
     WebView,
-    WebViewOptions,
-    WebViewContentUrl,
-    WebViewNotification,
+    Options,
+    ContentUrl,
+    Notification,
 )
 
 
 async def main():
     print("Creating webview")
-    config = WebViewOptions(
+    config = Options(
         title="Load Url Example",
-        load=WebViewContentUrl(
+        load=ContentUrl(
             url="https://example.com",
             headers={
                 "Content-Type": "text/html",
@@ -36,7 +33,7 @@ async def main():
 
     async with WebView(config) as webview:
 
-        async def handle_start(event: WebViewNotification):
+        async def handle_start(event: Notification):
             await webview.open_devtools()
             await asyncio.sleep(2)  # Sleep for 2 seconds
             await webview.load_url(
@@ -53,4 +50,3 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/src/clients/python/examples/simple.py
+++ b/src/clients/python/examples/simple.py
@@ -1,34 +1,34 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "webview-python",
+#     "justbe-webview",
 # ]
 #
 # [tool.uv.sources]
-# webview-python = { path = "../" }
+# justbe-webview = { path = "../" }
 # ///
 import asyncio
 
-from webview_python import (
+from justbe_webview import (
     WebView,
-    WebViewOptions,
-    WebViewContentHtml,
-    WebViewNotification,
+    Options,
+    ContentHtml,
+    Notification,
 )
 
 
 async def main():
     print("Creating webview")
-    config = WebViewOptions(
+    config = Options(
         title="Simple",
-        load=WebViewContentHtml(html="<h1>Hello, World!</h1>"),
+        load=ContentHtml(html="<h1>Hello, World!</h1>"),
         devtools=True,
         initializationScript="console.log('This is printed from initializationScript!')",
     )
 
     async with WebView(config) as webview:
 
-        async def handle_start(event: WebViewNotification):
+        async def handle_start(event: Notification):
             print("handle_start called")
             await webview.set_title("Title set from Python")
             current_title = await webview.get_title()

--- a/src/clients/python/examples/window_size.py
+++ b/src/clients/python/examples/window_size.py
@@ -1,22 +1,22 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "webview-python",
+#     "justbe-webview",
 # ]
 #
 # [tool.uv.sources]
-# webview-python = { path = "../" }
+# justbe-webview = { path = "../" }
 # ///
 import asyncio
 
-from webview_python import WebView, WebViewOptions, WebViewContentHtml, IpcNotification
+from justbe_webview import WebView, Options, ContentHtml, IpcNotification, Size
 
 
 async def main():
     print("Creating webview")
-    config = WebViewOptions(
+    config = Options(
         title="Window Size",
-        load=WebViewContentHtml(
+        load=ContentHtml(
             html="""
             <h1>Window Sizes</h1>
             <div style="display: flex; gap: 10px;">
@@ -26,7 +26,7 @@ async def main():
             </div>
             """
         ),
-        size={"width": 800, "height": 200},
+        size=Size(width=800, height=200),
         ipc=True,
     )
 
@@ -50,4 +50,3 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/src/clients/python/pyproject.toml
+++ b/src/clients/python/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "webview-python"
-version = "0.1.0"
-description = "Add your description here"
+name = "justbe-webview"
+version = "0.0.1"
+description = "A simple webview client"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/clients/python/src/justbe_webview/__init__.py
+++ b/src/clients/python/src/justbe_webview/__init__.py
@@ -10,6 +10,8 @@ from pyee.asyncio import AsyncIOEventEmitter
 import msgspec
 import sys
 
+from .schemas import *
+
 # Import schemas
 from .schemas import (
     NotificationMessage,
@@ -43,7 +45,6 @@ from .schemas import (
     LoadHtmlRequest,
     LoadUrlRequest,
     Size,
-    ContentHtml as WebViewContentHtml,
 )
 
 # Constants

--- a/src/clients/python/src/justbe_webview/schemas.py
+++ b/src/clients/python/src/justbe_webview/schemas.py
@@ -3,6 +3,48 @@ from enum import Enum
 from typing import Union
 import msgspec
 
+__all__ = [
+    "AckResponse",
+    "BooleanResultType",
+    "ClosedNotification",
+    "Content",
+    "ContentHtml",
+    "ContentUrl",
+    "ErrResponse",
+    "EvalRequest",
+    "FloatResultType",
+    "FullscreenRequest",
+    "GetSizeRequest",
+    "GetTitleRequest",
+    "GetVersionRequest",
+    "IpcNotification",
+    "IsVisibleRequest",
+    "LoadHtmlRequest",
+    "LoadUrlRequest",
+    "MaximizeRequest",
+    "Message",
+    "MinimizeRequest",
+    "Notification",
+    "NotificationMessage",
+    "OpenDevToolsRequest",
+    "Options",
+    "Request",
+    "Response",
+    "ResponseMessage",
+    "ResultResponse",
+    "ResultType",
+    "SetSizeRequest",
+    "SetTitleRequest",
+    "SetVisibilityRequest",
+    "Size",
+    "SizeResultType",
+    "SizeWithScale",
+    "StartedNotification",
+    "StringResultType",
+    "WindowSize",
+    "WindowSizeStates"
+]
+
 class StartedNotification(msgspec.Struct, tag_field="$type", tag="started"): 
     version: str
     """The version of the webview binary""" 

--- a/src/clients/python/uv.lock
+++ b/src/clients/python/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -78,6 +79,37 @@ sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
 ]
+
+[[package]]
+name = "justbe-webview"
+version = "0.0.1"
+source = { editable = "." }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "httpx" },
+    { name = "msgspec" },
+    { name = "pyee" },
+    { name = "python-ulid" },
+    { name = "types-aiofiles" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiofiles", specifier = ">=24.1.0" },
+    { name = "httpx", specifier = ">=0.27.2" },
+    { name = "msgspec", specifier = ">=0.19.0" },
+    { name = "pyee", specifier = ">=12.0.0" },
+    { name = "python-ulid", specifier = ">=3.0.0" },
+    { name = "types-aiofiles", specifier = ">=24.1.0.20240626" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.6.9" }]
 
 [[package]]
 name = "msgspec"
@@ -173,34 +205,3 @@ sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec3
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
 ]
-
-[[package]]
-name = "webview-python"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "aiofiles" },
-    { name = "httpx" },
-    { name = "msgspec" },
-    { name = "pyee" },
-    { name = "python-ulid" },
-    { name = "types-aiofiles" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiofiles", specifier = ">=24.1.0" },
-    { name = "httpx", specifier = ">=0.27.2" },
-    { name = "msgspec", specifier = ">=0.19.0" },
-    { name = "pyee", specifier = ">=12.0.0" },
-    { name = "python-ulid", specifier = ">=3.0.0" },
-    { name = "types-aiofiles", specifier = ">=24.1.0.20240626" },
-]
-
-[package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.6.9" }]


### PR DESCRIPTION
This (hopefully) fixes up the python client and preps it for release. For consistency sake I'm going to publish this as `justbe-webview`. 

I did a few things here
- Generate an `__all__` block for the generated python schemas to ensure I could export all the generated code from the package
- Renamed the project from `python-webview` to `justbe-webview`
- Added a GitHub action to automate the publishing of the package