### PR TITLE
Cache rust dependecies

### DIFF
--- a/.github/workflows/rust-binary.yml
+++ b/.github/workflows/rust-binary.yml
@@ -43,6 +43,17 @@ jobs:
           cache_key_prefix: mise-${{ hashFiles('mise.toml') }}-${{ matrix.target }}
           experimental: true
 
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "binary-${{ matrix.target }}"
+          workspaces: "."
+          cache-directories: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+
       - run: mise x -- rustup target add ${{ matrix.target }}
       - run: mise run ci:install-deps
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,6 +13,12 @@ jobs:
           cache_key_prefix: mise-{{hashFiles('mise.toml')}}
           experimental: true
 
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "lint"
+
       - name: Lint
         run: mise lint
 
@@ -37,6 +43,12 @@ jobs:
         with:
           cache_key_prefix: mise-{{hashFiles('mise.toml')}}
           experimental: true
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "codegen"
 
       - name: Run codegen
         run: mise run gen


### PR DESCRIPTION
A few parts of the build are taking _forever_ because the rust dependencies aren't cached and its causing them to recompile. This hopefully mitigates that issue. 