### PR TITLE
Fix webview binary path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.0.2 Python Client; 1.0.1-rc.1 Deno Client; 0.3.0 binary -- 2025-02-23
+
+Binary
+
+- Updated wry to 0.49.0
+- Updated tao to 0.32.0
+
+Python Client
+
+- Updated webview binary to 0.3.0
+- Fixed readme
+- Fixed binary path being wrong
+- Fixed windows binary name being incorrectly constructed
+
+Deno Client
+
+- Updated webview to 0.3.0
+
+## 0.0.1 Python Client; 0.2.0 binary -- 2025-02-18
+
+- Initial release of the python client
+
 ## 1.0.0-rc.1 Deno Client; 0.2.0 binary -- 2025-02-17
 
 - Added new logging that can be triggered with the `LOG_LEVEL` environment variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Python Client
 - Fixed readme
 - Fixed binary path being wrong
 - Fixed windows binary name being incorrectly constructed
+- Fixed an issue where events weren't being acknowledged
 
 Deno Client
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "webview"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actson",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webview"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [profile.release]

--- a/mise.toml
+++ b/mise.toml
@@ -129,7 +129,7 @@ depends = ["lint:*"]
 description = "Run a python example"
 depends = ["build:python"]
 dir = "src/clients/python"
-run = "uv run examples/{{arg(name=\"example\")}}.py"
+run = "uv run -n examples/{{arg(name=\"example\")}}.py"
 env = { LOG_LEVEL = "debug", WEBVIEW_BIN = "../../../target/debug/webview" }
 
 [tasks."example:deno"]

--- a/src/clients/deno/deno.json
+++ b/src/clients/deno/deno.json
@@ -2,7 +2,7 @@
   "name": "@justbe/webview",
   "exports": "./main.ts",
   "license": "MIT",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.1-rc.1",
   "publish": {
     "include": ["README.md", "LICENSE", "*.ts", "schemas/*.ts"]
   },

--- a/src/clients/deno/main.ts
+++ b/src/clients/deno/main.ts
@@ -55,7 +55,7 @@ if (
 
 // Should match the cargo package version
 /** The version of the webview binary that's expected */
-export const BIN_VERSION = "0.2.0";
+export const BIN_VERSION = "0.3.0";
 
 type WebViewNotification = Extract<
   Message,

--- a/src/clients/python/src/justbe_webview/__init__.py
+++ b/src/clients/python/src/justbe_webview/__init__.py
@@ -219,7 +219,7 @@ class WebView:
         def set_result(event: Union[AckResponse, ResultResponse, ErrResponse]) -> None:
             future.set_result(event)
 
-        self.internal_event.once(request.id, set_result)  # type: ignore
+        self.internal_event.once(str(request.id), set_result)  # type: ignore
 
         assert self.process.stdin is not None
         encoded = msgspec.json.encode(request)

--- a/src/clients/python/src/justbe_webview/__init__.py
+++ b/src/clients/python/src/justbe_webview/__init__.py
@@ -48,7 +48,7 @@ from .schemas import (
 )
 
 # Constants
-BIN_VERSION = "0.2.0"
+BIN_VERSION = "0.3.0"
 
 T = TypeVar("T", bound=WebViewNotification)
 

--- a/src/clients/python/src/justbe_webview/__init__.py
+++ b/src/clients/python/src/justbe_webview/__init__.py
@@ -101,9 +101,12 @@ async def get_webview_bin(options: WebViewOptions) -> str:
     elif platform.system() == "Linux":
         url += "-linux"
     elif platform.system() == "Windows":
-        url += "-windows.exe"
+        url += "-windows"
     else:
         raise ValueError("Unsupported OS")
+
+    if platform.system() == "Windows":
+        url += ".exe"
 
     url += flags
 

--- a/src/clients/python/src/justbe_webview/__init__.py
+++ b/src/clients/python/src/justbe_webview/__init__.py
@@ -85,7 +85,7 @@ async def get_webview_bin(options: WebViewOptions) -> str:
         flags = "-transparent"
 
     cache_dir = get_cache_dir()
-    file_name = f"deno-webview-{BIN_VERSION}{flags}"
+    file_name = f"webview-{BIN_VERSION}{flags}"
     if platform.system() == "Windows":
         file_name += ".exe"
     file_path = cache_dir / file_name
@@ -93,7 +93,7 @@ async def get_webview_bin(options: WebViewOptions) -> str:
     if file_path.exists():
         return str(file_path)
 
-    url = f"https://github.com/zephraph/webview/releases/download/webview-v{BIN_VERSION}/deno-webview"
+    url = f"https://github.com/zephraph/webview/releases/download/webview-v{BIN_VERSION}/webview"
     if platform.system() == "Darwin":
         url += "-mac"
         if platform.machine() == "arm64":


### PR DESCRIPTION
Fixes #141

Thanks to @daidalvi for identifying both the issues and the fix. There are two distinct problems this PR fixes. 

1. The filepath to the binary in GitHub releases was wrong. It still referenced the old `deno-webview` which I renamed when moving to multi-client support
2. Fixes the logic for constructing the windows exe path. This is correct in the deno client, but in the python client I was adding the `.exe` _before_ adding the flags
3. Upgrades the webview binary
4. Fixes an issue where events weren't properly firing in the python client