### PR TITLE
Fix windows path being incorrectly constructed in python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.3 Python Client -- 2025-03-01
+
+- Fixed a bug where the windows binary path was still incorrect (thanks @daidalvi)
+
 ## 0.0.2 Python Client; 1.0.1-rc.1 Deno Client; 0.3.0 binary -- 2025-02-23
 
 Binary
@@ -27,8 +31,8 @@ Deno Client
 
 - Added new logging that can be triggered with the `LOG_LEVEL` environment variable
 
-- [BREAKING] Changed some typenames/zod schemas not to include `Webview` in the name. 
-- [BREAKING] Updated code generation to support multiple clients which necessitated a breaking change for the Deno client. 
+- [BREAKING] Changed some typenames/zod schemas not to include `Webview` in the name.
+- [BREAKING] Updated code generation to support multiple clients which necessitated a breaking change for the Deno client.
 
   ```diff
   using webview = await createWebView({
@@ -41,7 +45,7 @@ Deno Client
       "console.log('This is printed from initializationScript!')",
   });
   ```
-  `html` or `url` must be wrapped in an object and passed to `load`. 
+  `html` or `url` must be wrapped in an object and passed to `load`.
 
 ## 0.0.17 (binary 0.1.14) -- 2024-10-02
 

--- a/src/clients/python/pyproject.toml
+++ b/src/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "justbe-webview"
-version = "0.0.2"
+version = "0.0.3"
 description = "A simple webview client"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/clients/python/src/justbe_webview/__init__.py
+++ b/src/clients/python/src/justbe_webview/__init__.py
@@ -105,10 +105,10 @@ async def get_webview_bin(options: WebViewOptions) -> str:
     else:
         raise ValueError("Unsupported OS")
 
+    url += flags
+
     if platform.system() == "Windows":
         url += ".exe"
-
-    url += flags
 
     async with httpx.AsyncClient() as client:
         response = await client.get(url, follow_redirects=True)


### PR DESCRIPTION
I'd hoped I'd fixed this in the 0.0.2 release but as @daidalvi pointed out in #145 it's still a bit broken. I'll follow up with some tests for this to ensure the path construction happens correctly on the various platforms. I really need some good tests regardless. 