### PR TITLE
Configure Zed editor to use Deno LSP for TypeScript only

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,17 @@
+{
+  "languages": {
+    "TypeScript": {
+      "language_servers": ["deno", "!typescript-language-server", "!vtsls"]
+    }
+  },
+  "lsp": {
+    "deno": {
+      "settings": {
+        "deno": {
+          "enable": true,
+          "enablePaths": ["src/clients/deno"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Enable Deno language server and disable other TypeScript LSPs in Zed settings.  
Restrict Deno LSP activation to src/clients/deno to improve language server accuracy and performance.