### PR TITLE
Fix lint:ast-grep CI failure by installing ast-grep via aqua

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 deno = "2.4.2"
-"npm:@ast-grep/cli" = "0.39.6"
+ast-grep = "0.39.6"
 rust = { version = "1.90.0", components="rustfmt,clippy,rust-analyzer" }
 ruff = "0.14.0"
 uv = "0.9.2"


### PR DESCRIPTION
## Summary

- Switch `ast-grep` install from `npm:@ast-grep/cli` to the default aqua-backed registry entry in `mise.toml`.
- The npm package ships placeholder shell scripts for `sg`/`ast-grep` that a `postinstall.js` is supposed to overwrite with the real binary. Under mise on Linux CI the shim path keeps pointing at the placeholders, so `sg scan` ran the placeholder text and the shell exited 127 with `sg: 1: This: not found` / `sg: 2: N.B.: not found`.
- The aqua entry downloads prebuilt release binaries directly from the ast-grep GitHub releases, so both `sg` and `ast-grep` shims work out of the box. Version pin (`0.39.6`) and renovate auto-updates (via `config:best-practices`) are unaffected.

## Test plan

- [x] `mise run lint:ast-grep` passes locally with the new install source.
- [ ] CI `lint` job passes on this PR.