### PR TITLE
Fix lint:ast-grep CI failure by installing ast-grep via aqua

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 deno = "2.4.2"
-"npm:@ast-grep/cli" = "0.39.6"
+ast-grep = "0.39.6"
 rust = { version = "1.90.0", components="rustfmt,clippy,rust-analyzer" }
 ruff = "0.14.0"
 uv = "0.9.2"


### PR DESCRIPTION
tl;dr: Linting was broken. It's fixed by just directly referencing `ast-grep` from the aqua registry instead of installing it via npm. 

The npm:@ast-grep/cli package ships placeholder shell scripts for the sg and ast-grep binaries that a postinstall.js is supposed to replace. Under mise on Linux CI those placeholders aren't replaced at the shim path, so `sg scan` ran the placeholder text and the shell errored with `sg: 1: This: not found` (exit 127). Switching to the aqua-backed ast-grep registry entry installs real prebuilt release binaries.